### PR TITLE
Increase padding on movie buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -2135,6 +2135,10 @@ h2 {
   color: #fff;
 }
 
+.movie-action {
+  padding: 6px 14px;
+}
+
 @media (max-width: 768px) {
   .calendar-mobile-tabs {
     display: flex;


### PR DESCRIPTION
## Summary
- add a dedicated style for movie action buttons to give them more horizontal padding

## Testing
- Not run (fails in this environment because `vitest` cannot load the optional `@rollup/rollup-linux-x64-gnu` dependency)

------
https://chatgpt.com/codex/tasks/task_e_68e2b67a73f48327ba86792d942ff26c