### PR TITLE
Add geolocation-based restaurant sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,12 @@
           <input type="text" id="restaurantsApiKey" placeholder="Leave blank to use server key" />
           <span style="font-size:0.75rem; margin-top:0.25rem;">You can generate one at <a href="https://www.yelp.com/developers/v3/manage_app" target="_blank" rel="noopener noreferrer">Yelp Fusion</a>.</span>
         </div>
+        <div style="display:flex; flex-direction:column; gap:0.25rem;">
+          <button type="button" id="restaurantsUseLocationBtn" aria-label="Use current location">Use current location</button>
+          <span id="restaurantsLocationStatus" style="font-size:0.75rem; min-height:1.25em;" aria-live="polite"></span>
+        </div>
         <button type="button" id="restaurantsSearchBtn" aria-label="Search restaurants">Search</button>
-        <div style="font-size:0.75rem; max-width:260px;">Powered by Yelp Fusion. The server will use its configured <code>YELP_API_KEY</code> by default; enter your own here to override.</div>
+        <div style="font-size:0.75rem; max-width:260px;">Powered by Yelp Fusion. The server will use its configured <code>YELP_API_KEY</code> by default; enter your own here to override. Use your current location to see the closest restaurants first.</div>
       </div>
       <div id="restaurantsResults" class="decision-container"></div>
     </div>

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -8,6 +8,8 @@ function setupDom() {
         <input id="restaurantsCity" />
         <input id="restaurantsCuisine" />
         <div id="restaurantsApiKeyContainer"><input id="restaurantsApiKey" /></div>
+        <button id="restaurantsUseLocationBtn"></button>
+        <span id="restaurantsLocationStatus"></span>
         <button id="restaurantsSearchBtn"></button>
       </div>
       <div id="restaurantsResults"></div>
@@ -109,7 +111,50 @@ describe('initRestaurantsPanel', () => {
     document.getElementById('restaurantsSearchBtn').click();
 
     const results = document.getElementById('restaurantsResults');
-    expect(results.textContent).toContain('Enter a city');
+    expect(results.textContent).toContain('Enter a city or use your current location');
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('requests current location and searches by proximity', async () => {
+    const dom = setupDom();
+    global.window = dom.window;
+    global.document = dom.window.document;
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get: () => global.localStorage
+    });
+
+    const geoMock = {
+      getCurrentPosition: vi.fn()
+    };
+    Object.defineProperty(window.navigator, 'geolocation', {
+      configurable: true,
+      value: geoMock
+    });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([])
+    });
+
+    await initRestaurantsPanel();
+
+    const successPayload = {
+      coords: { latitude: 30.2672, longitude: -97.7431 }
+    };
+
+    geoMock.getCurrentPosition.mockImplementation(successCb => {
+      successCb(successPayload);
+    });
+
+    document.getElementById('restaurantsUseLocationBtn').click();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('latitude=30.2672'),
+      expect.anything()
+    );
+    expect(fetch.mock.calls[0][0]).toContain('longitude=-97.7431');
   });
 });


### PR DESCRIPTION
## Summary
- allow the restaurants backend endpoint to accept coordinates and sort by proximity when latitude/longitude are provided
- enhance the restaurants panel UI to let users fetch their current location, search without a city, and display distances in the results
- expand the restaurants panel tests to cover geolocation flows and updated validation messaging

## Testing
- npm test *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b65fe22083278f23811f47b50e8d