### PR TITLE
Add TMDB credit fetching

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -4,6 +4,7 @@ const MOVIE_PREFS_KEY = 'moviePreferences';
 const API_KEY_STORAGE = 'moviesApiKey';
 const DEFAULT_INTEREST = 3;
 const MAX_DISCOVER_PAGES = 3;
+const MAX_CREDIT_REQUESTS = 20;
 const PREF_COLLECTION = 'moviePreferences';
 const MIN_VOTE_AVERAGE = 7;
 const MIN_VOTE_COUNT = 50;
@@ -35,6 +36,13 @@ const handlers = {
   handleKeydown: null,
   handleChange: null
 };
+
+function getNameList(names) {
+  if (!Array.isArray(names)) return [];
+  return names
+    .map(name => (typeof name === 'string' ? name.trim() : ''))
+    .filter(Boolean);
+}
 
 function meetsQualityThreshold(movie) {
   if (!movie || typeof movie !== 'object') return false;
@@ -175,7 +183,9 @@ function summarizeMovie(movie) {
     overview: movie.overview || '',
     vote_average: movie.vote_average ?? null,
     vote_count: movie.vote_count ?? null,
-    genre_ids: Array.isArray(movie.genre_ids) ? movie.genre_ids : []
+    genre_ids: Array.isArray(movie.genre_ids) ? movie.genre_ids : [],
+    topCast: getNameList(movie.topCast).slice(0, 5),
+    directors: getNameList(movie.directors).slice(0, 3)
   };
 }
 
@@ -195,6 +205,72 @@ function appendMeta(list, label, value) {
   strong.textContent = `${label}:`;
   item.append(strong, ` ${value}`);
   list.appendChild(item);
+}
+
+function appendPeopleMeta(list, label, names) {
+  const values = getNameList(names);
+  if (!values.length) return;
+  appendMeta(list, label, values.join(', '));
+}
+
+function applyCreditsToMovie(movie, credits) {
+  if (!movie || !credits) return;
+  const cast = Array.isArray(credits.cast) ? credits.cast : [];
+  const crew = Array.isArray(credits.crew) ? credits.crew : [];
+
+  const topCast = cast
+    .filter(person => person && typeof person.name === 'string')
+    .slice(0, 5)
+    .map(person => person.name.trim())
+    .filter(Boolean);
+
+  const directors = crew
+    .filter(person => person && person.job === 'Director' && typeof person.name === 'string')
+    .map(person => person.name.trim())
+    .filter(Boolean);
+
+  if (topCast.length) {
+    movie.topCast = Array.from(new Set(topCast));
+  }
+  if (directors.length) {
+    movie.directors = Array.from(new Set(directors));
+  }
+}
+
+async function fetchCreditsForMovie(movieId, { usingProxy, apiKey }) {
+  if (!movieId) return null;
+  try {
+    if (usingProxy) {
+      return await callTmdbProxy('credits', { movie_id: movieId });
+    }
+
+    if (!apiKey) return null;
+    const url = new URL(`https://api.themoviedb.org/3/movie/${movieId}/credits`);
+    url.searchParams.set('api_key', apiKey);
+    const res = await fetch(url.toString());
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error('Failed to fetch credits for movie', movieId, err);
+    return null;
+  }
+}
+
+async function enrichMoviesWithCredits(movies, options) {
+  if (!Array.isArray(movies) || !movies.length) return;
+  const limit = Math.min(MAX_CREDIT_REQUESTS, movies.length);
+  const targets = movies.slice(0, limit).filter(movie => movie && movie.id != null);
+  if (!targets.length) return;
+
+  const creditsList = await Promise.all(
+    targets.map(movie => fetchCreditsForMovie(movie.id, options))
+  );
+
+  creditsList.forEach((credits, index) => {
+    const movie = targets[index];
+    if (!movie) return;
+    applyCreditsToMovie(movie, credits);
+  });
 }
 
 async function setStatus(movie, status, options = {}) {
@@ -292,6 +368,8 @@ function renderFeed() {
     appendMeta(metaList, 'Average Score', movie.vote_average ?? 'N/A');
     appendMeta(metaList, 'Votes', movie.vote_count ?? 'N/A');
     appendMeta(metaList, 'Release Date', movie.release_date || 'Unknown');
+    appendPeopleMeta(metaList, 'Director', movie.directors);
+    appendPeopleMeta(metaList, 'Cast', movie.topCast);
 
     if (metaList.childNodes.length) {
       info.appendChild(metaList);
@@ -378,6 +456,14 @@ function renderInterestedList() {
       info.appendChild(overview);
     }
 
+    const metaList = document.createElement('ul');
+    metaList.className = 'movie-meta';
+    appendPeopleMeta(metaList, 'Director', movie.directors);
+    appendPeopleMeta(metaList, 'Cast', movie.topCast);
+    if (metaList.childNodes.length) {
+      info.appendChild(metaList);
+    }
+
     const controls = document.createElement('div');
     controls.className = 'button-row';
     controls.append(makeActionButton('Remove', () => clearStatus(movie.id)));
@@ -429,6 +515,14 @@ function renderWatchedList() {
       const overview = document.createElement('p');
       overview.textContent = movie.overview;
       info.appendChild(overview);
+    }
+
+    const metaList = document.createElement('ul');
+    metaList.className = 'movie-meta';
+    appendPeopleMeta(metaList, 'Director', movie.directors);
+    appendPeopleMeta(metaList, 'Cast', movie.topCast);
+    if (metaList.childNodes.length) {
+      info.appendChild(metaList);
     }
 
     const controls = document.createElement('div');
@@ -600,6 +694,7 @@ async function loadMovies() {
     const movies = applyPriorityOrdering(
       usingProxy ? await fetchMoviesFromProxy() : await fetchMoviesDirect(apiKey)
     );
+    await enrichMoviesWithCredits(movies, { usingProxy, apiKey });
     const genres = usingProxy ? await fetchGenreMapFromProxy() : await fetchGenreMapDirect(apiKey);
     currentMovies = movies;
     genreMap = genres;

--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -106,9 +106,19 @@ describe('initMoviesPanel', () => {
       ]
     };
     const empty = { results: [] };
+    const credits = {
+      cast: [
+        { name: 'Lead Star' },
+        { name: 'Supporting Actor' }
+      ],
+      crew: [
+        { job: 'Director', name: 'Jane Doe' },
+        { job: 'Producer', name: 'Producer Person' }
+      ]
+    };
     const genres = { genres: [{ id: 28, name: 'Action' }] };
 
-    configureFetchResponses([page, empty, empty, genres]);
+    configureFetchResponses([page, empty, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -117,7 +127,10 @@ describe('initMoviesPanel', () => {
     expect(card.textContent).toContain('Sample Movie');
     expect(card.textContent).toContain('Average Score: 7.5');
     expect(card.textContent).toContain('Votes: 120');
-    expect(card.querySelector('.movie-meta')?.textContent).toContain('Genres: Action');
+    const metaText = card.querySelector('.movie-meta')?.textContent || '';
+    expect(metaText).toContain('Genres: Action');
+    expect(metaText).toContain('Director: Jane Doe');
+    expect(metaText).toContain('Cast: Lead Star, Supporting Actor');
 
     const buttons = Array.from(card.querySelectorAll('button')).map(b => b.textContent);
     expect(buttons).toEqual(['Watched Already', 'Not Interested', 'Interested']);
@@ -163,9 +176,13 @@ describe('initMoviesPanel', () => {
       ]
     };
     const empty = { results: [] };
+    const credits = {
+      cast: [{ name: 'Award Winner' }],
+      crew: [{ job: 'Director', name: 'Visionary Director' }]
+    };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, genres]);
+    configureFetchResponses([page, empty, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -204,9 +221,17 @@ describe('initMoviesPanel', () => {
       ]
     };
     const empty = { results: [] };
+    const creditsHigh = {
+      cast: [{ name: 'Popular Lead' }],
+      crew: [{ job: 'Director', name: 'High Director' }]
+    };
+    const creditsLow = {
+      cast: [{ name: 'Indie Lead' }],
+      crew: [{ job: 'Director', name: 'Low Director' }]
+    };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, genres]);
+    configureFetchResponses([page, empty, empty, creditsHigh, creditsLow, genres]);
 
     await initMoviesPanel();
 
@@ -235,9 +260,13 @@ describe('initMoviesPanel', () => {
       ]
     };
     const empty = { results: [] };
+    const credits = {
+      cast: [{ name: 'Breakout Star' }],
+      crew: [{ job: 'Director', name: 'Indie Director' }]
+    };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, genres]);
+    configureFetchResponses([page, empty, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -263,6 +292,8 @@ describe('initMoviesPanel', () => {
     expect(label?.textContent).toBe('Interest: 5');
     const stored = JSON.parse(global.localStorage.getItem('moviePreferences'));
     expect(stored['2'].interest).toBe(5);
+    const meta = document.querySelector('#savedMoviesList .movie-meta')?.textContent || '';
+    expect(meta).toContain('Director: Indie Director');
   });
 
   it('routes movie requests through the Cloud Function proxy', async () => {
@@ -284,9 +315,13 @@ describe('initMoviesPanel', () => {
       ]
     };
     const empty = { results: [] };
+    const credits = {
+      cast: [{ name: 'Proxy Star' }],
+      crew: [{ job: 'Director', name: 'Proxy Director' }]
+    };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, genres]);
+    configureFetchResponses([page, empty, empty, credits, genres]);
 
     await initMoviesPanel();
     const calledUrls = fetch.mock.calls.map(args => args[0]);
@@ -294,6 +329,7 @@ describe('initMoviesPanel', () => {
     expect(calledUrls.every(url => String(url).startsWith('https://mock-functions.net/tmdbProxy'))).toBe(true);
     expect(calledUrls.some(url => String(url).includes('endpoint=discover'))).toBe(true);
     expect(calledUrls.some(url => String(url).includes('endpoint=genres'))).toBe(true);
+    expect(calledUrls.some(url => String(url).includes('endpoint=credits'))).toBe(true);
     expect(calledUrls.some(url => String(url).includes('api_key='))).toBe(false);
     expect(global.localStorage.getItem('moviesApiKey')).toBeNull();
   });
@@ -317,9 +353,13 @@ describe('initMoviesPanel', () => {
       ]
     };
     const empty = { results: [] };
+    const credits = {
+      cast: [{ name: 'Iconic Star' }],
+      crew: [{ job: 'Director', name: 'Famed Director' }]
+    };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, genres]);
+    configureFetchResponses([page, empty, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -361,9 +401,13 @@ describe('initMoviesPanel', () => {
       ]
     };
     const empty = { results: [] };
+    const credits = {
+      cast: [{ name: 'Remote Star' }],
+      crew: [{ job: 'Director', name: 'Remote Director' }]
+    };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, genres]);
+    configureFetchResponses([page, empty, empty, credits, genres]);
 
     await initMoviesPanel();
 


### PR DESCRIPTION
## Summary
- allow the TMDB Cloud Function proxy to forward movie credit requests for individual titles
- fetch cast and director details for prioritized movies, surface them in the UI, and persist them with saved entries
- extend Vitest coverage to validate credit metadata rendering and proxy usage

## Testing
- npm test *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu' due to missing optional dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b686c1688327b6805daa5541a480