### PR TITLE
Remove Live Music API usage notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,9 +86,6 @@
             <span id="spotifyStatus" style="margin-right:.5rem;"></span>
             <input type="password" id="spotifyToken" placeholder="Spotify Access Token" style="margin-right:.5rem;">
             <input type="password" id="ticketmasterApiKey" placeholder="Ticketmaster API Key" style="margin-right:.5rem;">
-            <div style="font-size:0.8rem;margin-top:0.5rem;">
-              Uses the <a href="https://developer.spotify.com/documentation/web-api/" target="_blank" rel="noopener noreferrer">Spotify Web API</a> to fetch your top artists and the <a href="https://developer.ticketmaster.com/products-and-docs/apis/discovery-api/v2/" target="_blank" rel="noopener noreferrer">Ticketmaster Discovery API</a> to find shows.
-            </div>
           </div>
       <div id="ticketmasterList" class="decision-container"></div>
         </div>


### PR DESCRIPTION
## Summary
- remove the informational copy in the Live Music panel that referenced the Spotify and Ticketmaster APIs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ba2712d883278f231cd7f878aadb