### PR TITLE
Enhance live music cards and filter by distance

### DIFF
--- a/style.css
+++ b/style.css
@@ -581,6 +581,126 @@ button:hover {
   position: relative;
 }
 
+#ticketmasterList {
+  width: 100%;
+}
+
+.shows-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  padding: 0;
+  margin: 0;
+}
+
+.show-card {
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid #e1ebe4;
+  box-shadow: 0 8px 18px rgba(25, 55, 45, 0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.show-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 28px rgba(25, 55, 45, 0.14);
+}
+
+.show-card__media {
+  position: relative;
+  padding-top: 56.25%;
+  background: #f3f8f4;
+}
+
+.show-card__media img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.show-card__content {
+  padding: 1rem 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.show-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.show-card__title {
+  margin: 0;
+  color: #16352f;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.show-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.show-card__date {
+  color: #335c52;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.show-card__tag {
+  background: #d2efe2;
+  color: #1f4a40;
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.show-card__location {
+  color: #3d5f58;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.show-card__cta {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  background: linear-gradient(135deg, #2f7f70, #3fa284);
+  color: #ffffff;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: filter 0.2s ease;
+}
+
+.show-card__cta:hover {
+  filter: brightness(1.05);
+}
+
+.shows-empty {
+  background: #f0faf5;
+  border: 1px dashed #a4cabb;
+  color: #1f4a40;
+  padding: 1rem;
+  border-radius: 12px;
+  text-align: center;
+  font-weight: 600;
+}
+
 
 .goal-drop-indicator {
   outline: 2px dashed #ccc;

--- a/tests/showsSpotify.test.js
+++ b/tests/showsSpotify.test.js
@@ -20,6 +20,7 @@ describe('initShowsPanel', () => {
   let initShowsPanel;
   beforeEach(async () => {
     storage.clear();
+    vi.resetModules();
     const dom = new JSDOM(`
       <button id="spotifyTokenBtn"></button>
       <span id="spotifyStatus"></span>
@@ -30,6 +31,15 @@ describe('initShowsPanel', () => {
     global.window = dom.window;
     global.document = dom.window.document;
     global.fetch = vi.fn();
+    global.navigator = {
+      geolocation: {
+        getCurrentPosition: vi.fn(success => {
+          success({
+            coords: { latitude: 30.2672, longitude: -97.7431 }
+          });
+        })
+      }
+    };
     window.__NO_SPOTIFY_REDIRECT = true;
     ({ initShowsPanel } = await import('../js/shows.js'));
   });
@@ -46,7 +56,16 @@ describe('initShowsPanel', () => {
               {
                 name: 'Concert',
                 dates: { start: { localDate: '2024-01-01' } },
-                _embedded: { venues: [{ name: 'Venue', city: { name: 'City' }, state: { stateCode: 'ST' } }] },
+                _embedded: {
+                  venues: [
+                    {
+                      name: 'Venue',
+                      city: { name: 'City' },
+                      state: { stateCode: 'ST' },
+                      location: { latitude: '30.26', longitude: '-97.74' }
+                    }
+                  ]
+                },
                 url: 'http://example.com'
               }
             ]
@@ -61,10 +80,67 @@ describe('initShowsPanel', () => {
     await flush();
 
     expect(fetch).toHaveBeenCalledTimes(3);
-    expect(document.querySelectorAll('#ticketmasterList li').length).toBe(1);
+    expect(document.querySelectorAll('.show-card').length).toBe(1);
     expect(fetch.mock.calls[2][0]).toContain('/api/ticketmaster');
     expect(fetch.mock.calls[2][0]).not.toContain('apiKey=');
-    expect(document.querySelector('#ticketmasterList li').textContent).toContain('Concert');
+    expect(document.querySelector('.show-card__title')?.textContent).toContain('Concert');
+    expect(document.querySelector('.show-card__cta')?.textContent).toBe('Get Tickets');
+  });
+
+  it('only shows events within 300 miles of the user', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ clientId: 'cid', hasTicketmasterKey: true }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [{ name: 'The Band' }] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          _embedded: {
+            events: [
+              {
+                id: 'near',
+                name: 'Austin Gig',
+                dates: { start: { localDate: '2024-02-01' } },
+                _embedded: {
+                  venues: [
+                    {
+                      name: 'Continental Club',
+                      city: { name: 'Austin' },
+                      state: { stateCode: 'TX' },
+                      location: { latitude: '30.2669', longitude: '-97.7428' }
+                    }
+                  ]
+                },
+                url: 'http://example.com/austin'
+              },
+              {
+                id: 'far',
+                name: 'NYC Arena',
+                dates: { start: { localDate: '2024-03-01' } },
+                _embedded: {
+                  venues: [
+                    {
+                      name: 'Madison Square Garden',
+                      city: { name: 'New York' },
+                      state: { stateCode: 'NY' },
+                      location: { latitude: '40.7505', longitude: '-73.9934' }
+                    }
+                  ]
+                },
+                url: 'http://example.com/nyc'
+              }
+            ]
+          }
+        })
+      });
+
+    localStorage.setItem('spotifyToken', 'token');
+    await initShowsPanel();
+
+    await flush();
+    await flush();
+
+    const cards = Array.from(document.querySelectorAll('.show-card__title')).map(el => el.textContent);
+    expect(cards).toEqual(['Austin Gig']);
   });
 
   it('stores credentials and cached values during OAuth flow', async () => {
@@ -97,6 +173,15 @@ describe('initShowsPanel', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ clientId: 'cid', hasTicketmasterKey: true }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'newTok' }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [] }) });
+    global.navigator = {
+      geolocation: {
+        getCurrentPosition: vi.fn(success => {
+          success({
+            coords: { latitude: 30.2672, longitude: -97.7431 }
+          });
+        })
+      }
+    };
     localStorage.setItem('spotifyCodeVerifier', 'ver');
     ({ initShowsPanel } = await import('../js/shows.js'));
 


### PR DESCRIPTION
## Summary
- add formatted date handling, require geolocation, and filter Ticketmaster events to within 300 miles
- restyle live music results as media cards with imagery, metadata chips, and clearer empty states
- expand unit tests to cover distance filtering and provide geolocation mocks for deterministic output

## Testing
- `npm test -- showsSpotify` *(fails: rollup optional dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bb3d39f48327827589805466ed12