### PR TITLE
Use Firebase Cloud Function for recipe proxy

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -1,7 +1,7 @@
 const API_BASE_URL =
   (typeof window !== 'undefined' && window.apiBaseUrl) ||
   (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
-  'https://dashboard-6aih.onrender.com';
+  'https://us-central1-decision-maker-4e1d3.cloudfunctions.net';
 
 export async function initRecipesPanel() {
   const listEl = document.getElementById('recipesList');
@@ -24,8 +24,9 @@ export async function initRecipesPanel() {
     if (searchBtn) searchBtn.disabled = true;
     listEl.innerHTML = '<em>Loading...</em>';
     try {
+      const base = API_BASE_URL.replace(/\/$/, '');
       const res = await fetch(
-        `${API_BASE_URL}/api/spoonacular?query=${encodeURIComponent(query)}`
+        `${base}/api/spoonacular?query=${encodeURIComponent(query)}`
       );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();

--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -35,7 +35,7 @@ describe('initRecipesPanel', () => {
     const textEl = document.querySelector('#recipesList li strong');
     expect(textEl.textContent).toBe('Chicken Soup');
     expect(fetch).toHaveBeenCalledWith(
-      'https://dashboard-6aih.onrender.com/api/spoonacular?query=chicken'
+      'https://us-central1-decision-maker-4e1d3.cloudfunctions.net/api/spoonacular?query=chicken'
     );
   });
 


### PR DESCRIPTION
## Summary
- add a Firebase Cloud Function that proxies Spoonacular with CORS and optional API key override
- point the recipes panel to the Firebase base URL and normalize the request path
- update the unit test expectation for the new proxy endpoint

## Testing
- npm test *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bb720f588327800142214d467ce2