### PR TITLE
Add helper to normalize movie credit names

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -38,6 +38,33 @@ const handlers = {
   handleChange: null
 };
 
+function getNameList(input) {
+  if (!input) return [];
+
+  if (Array.isArray(input)) {
+    return input
+      .map(entry => {
+        if (typeof entry === 'string') {
+          return entry.trim();
+        }
+        if (entry && typeof entry.name === 'string') {
+          return entry.name.trim();
+        }
+        return '';
+      })
+      .filter(Boolean);
+  }
+
+  if (typeof input === 'string') {
+    return input
+      .split(',')
+      .map(name => name.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
 function meetsQualityThreshold(movie, minAverage = MIN_VOTE_AVERAGE, minVotes = MIN_VOTE_COUNT) {
   if (!movie || typeof movie !== 'object') return false;
   const average = Number(movie.vote_average ?? 0);


### PR DESCRIPTION
## Summary
- add a utility to normalize lists of cast and crew names before rendering movies

## Testing
- `ROLLUP_SKIP_NODEJS_NATIVE=1 npm test -- -t "renders movies" --runInBand` *(fails: rollup optional native dependency missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bec38fbc8327bd419f9779af0e23