### PR TITLE
Add reverse geocoding to restaurant lookup

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -124,11 +124,46 @@ function renderResults(container, items) {
   container.appendChild(ul);
 }
 
-async function fetchRestaurants({ latitude, longitude }) {
+async function reverseGeocodeCity(latitude, longitude) {
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return '';
+  const params = new URLSearchParams({
+    format: 'jsonv2',
+    lat: String(latitude),
+    lon: String(longitude)
+  });
+  const url = `https://nominatim.openstreetmap.org/reverse?${params.toString()}`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Accept: 'application/json'
+      }
+    });
+    if (!res.ok) return '';
+    const data = await res.json();
+    const address = data?.address || {};
+    return (
+      address.city ||
+      address.town ||
+      address.village ||
+      address.municipality ||
+      address.locality ||
+      address.county ||
+      ''
+    );
+  } catch (err) {
+    console.warn('Reverse geocoding failed', err);
+    return '';
+  }
+}
+
+async function fetchRestaurants({ latitude, longitude, city }) {
   const params = new URLSearchParams();
   if (latitude && longitude) {
     params.set('latitude', String(latitude));
     params.set('longitude', String(longitude));
+  }
+  if (city) {
+    params.set('city', String(city));
   }
 
   const base = API_BASE_URL ? API_BASE_URL.replace(/\/$/, '') : '';
@@ -173,7 +208,8 @@ async function loadNearbyRestaurants(container) {
 
   try {
     const { latitude, longitude } = position.coords;
-    const data = await fetchRestaurants({ latitude, longitude });
+    const city = await reverseGeocodeCity(latitude, longitude);
+    const data = await fetchRestaurants({ latitude, longitude, city });
     const sorted = sortByRating(data);
     renderResults(container, sorted);
   } catch (err) {

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -46,17 +46,25 @@ describe('initRestaurantsPanel', () => {
       { name: 'Top Rated', rating: 4.8, reviewCount: 45 }
     ];
 
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(sampleData)
-    });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ address: { city: 'Austin' } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(sampleData)
+      });
 
     await initRestaurantsPanel();
 
     expect(geoMock.getCurrentPosition).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch.mock.calls[0][0]).toContain('latitude=30.2672');
-    expect(fetch.mock.calls[0][0]).toContain('longitude=-97.7431');
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[0][0]).toContain('reverse');
+    expect(fetch.mock.calls[1][0]).toContain('latitude=30.2672');
+    expect(fetch.mock.calls[1][0]).toContain('longitude=-97.7431');
+    expect(fetch.mock.calls[1][0]).toContain('city=Austin');
 
     const results = document.getElementById('restaurantsResults');
     const headings = Array.from(results.querySelectorAll('h3')).map(el => el.textContent);
@@ -104,10 +112,16 @@ describe('initRestaurantsPanel', () => {
     });
     global.navigator = window.navigator;
 
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      json: () => Promise.resolve({ error: 'failed' })
-    });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ address: { city: 'New York' } })
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ error: 'failed' })
+      });
 
     await initRestaurantsPanel();
 


### PR DESCRIPTION
## Summary
- add reverse geocoding to derive a city name from the user's coordinates
- include the city parameter when requesting restaurants and adjust tests for the new fetch sequence

## Testing
- npm test *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu' due to environment optional dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c04e7da08327b41c4f7e34cb3c23