### PR TITLE
Improve restaurant search coordinate handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -159,12 +159,16 @@ app.get('/api/spotify-client-id', (req, res) => {
 });
 
 app.get('/api/restaurants', async (req, res) => {
-  const { city, cuisine = '', latitude, longitude } = req.query || {};
+  const { city, cuisine = '' } = req.query || {};
+  const rawLatitude = req.query?.latitude;
+  const rawLongitude = req.query?.longitude;
+  const latitude = typeof rawLatitude === 'string' ? Number(rawLatitude) : Number(rawLatitude);
+  const longitude = typeof rawLongitude === 'string' ? Number(rawLongitude) : Number(rawLongitude);
   const yelpKey = req.get('x-api-key') || req.query.apiKey || process.env.YELP_API_KEY;
   if (!yelpKey) {
     return res.status(500).json({ error: 'missing yelp api key' });
   }
-  const hasCoords = latitude && longitude;
+  const hasCoords = Number.isFinite(latitude) && Number.isFinite(longitude);
   if (!city && !hasCoords) {
     return res.status(400).json({ error: 'missing location' });
   }
@@ -181,6 +185,7 @@ app.get('/api/restaurants', async (req, res) => {
     params.delete('location');
     params.set('latitude', String(latitude));
     params.set('longitude', String(longitude));
+    params.set('location', `${latitude},${longitude}`);
   }
   if (cuisine) {
     params.set('term', String(cuisine));

--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -126,9 +126,16 @@ function renderResults(container, items) {
 
 async function fetchRestaurants({ latitude, longitude }) {
   const params = new URLSearchParams();
-  if (latitude && longitude) {
-    params.set('latitude', String(latitude));
-    params.set('longitude', String(longitude));
+  const parsedLatitude =
+    typeof latitude === 'string' ? Number(latitude) : latitude;
+  const parsedLongitude =
+    typeof longitude === 'string' ? Number(longitude) : longitude;
+  const hasLatitude = Number.isFinite(parsedLatitude);
+  const hasLongitude = Number.isFinite(parsedLongitude);
+
+  if (hasLatitude && hasLongitude) {
+    params.set('latitude', String(parsedLatitude));
+    params.set('longitude', String(parsedLongitude));
   }
 
   const base = API_BASE_URL ? API_BASE_URL.replace(/\/$/, '') : '';


### PR DESCRIPTION
## Summary
- normalize latitude and longitude values on the client before invoking the restaurants API
- parse coordinate query parameters on the server and treat zero values as valid
- include a fallback location string in Yelp requests when coordinates are supplied

## Testing
- `npm test -- --runInBand` *(fails: missing optional @rollup/rollup-linux-x64-gnu dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c08841c483278d9733269de2e612