### PR TITLE
Adjust recipes proxy path for cloud functions host

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -25,8 +25,19 @@ export async function initRecipesPanel() {
     listEl.innerHTML = '<em>Loading...</em>';
     try {
       const base = API_BASE_URL.replace(/\/$/, '');
+      let proxyPath = '/api/spoonacular';
+      try {
+        const parsed = new URL(base);
+        if (parsed.hostname.endsWith('cloudfunctions.net')) {
+          proxyPath = '/spoonacularProxy';
+        }
+      } catch (err) {
+        if (/cloudfunctions\.net/.test(base)) {
+          proxyPath = '/spoonacularProxy';
+        }
+      }
       const res = await fetch(
-        `${base}/api/spoonacular?query=${encodeURIComponent(query)}`
+        `${base}${proxyPath}?query=${encodeURIComponent(query)}`
       );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();

--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -35,7 +35,7 @@ describe('initRecipesPanel', () => {
     const textEl = document.querySelector('#recipesList li strong');
     expect(textEl.textContent).toBe('Chicken Soup');
     expect(fetch).toHaveBeenCalledWith(
-      'https://us-central1-decision-maker-4e1d3.cloudfunctions.net/api/spoonacular?query=chicken'
+      'https://us-central1-decision-maker-4e1d3.cloudfunctions.net/spoonacularProxy?query=chicken'
     );
   });
 


### PR DESCRIPTION
## Summary
- detect when the recipes API base URL points at the Cloud Functions host and use the deployed spoonacular proxy path
- update the recipes panel unit test to expect the proxy endpoint

## Testing
- npm test *(fails: rollup native optional dependency @rollup/rollup-linux-x64-gnu is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c42999688327b5e7e327cf749720