### PR TITLE
Add Live Music interested events tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,16 @@
             <input type="password" id="spotifyToken" placeholder="Spotify Access Token" style="margin-right:.5rem;">
             <input type="password" id="ticketmasterApiKey" placeholder="Ticketmaster API Key" style="margin-right:.5rem;">
           </div>
-      <div id="ticketmasterList" class="decision-container"></div>
+          <div id="showsTabs" class="movie-tabs">
+            <button type="button" class="movie-tab shows-tab active" data-target="showsFeedSection">Discover</button>
+            <button type="button" class="movie-tab shows-tab" data-target="showsInterestedSection">Your Live Music Events</button>
+          </div>
+          <div id="showsFeedSection">
+            <div id="ticketmasterList" class="decision-container"></div>
+          </div>
+          <div id="showsInterestedSection" style="display:none;">
+            <div id="ticketmasterInterestedList" class="decision-container"></div>
+          </div>
         </div>
       </div>
     <!-- RECIPES PANEL -->

--- a/style.css
+++ b/style.css
@@ -2337,13 +2337,15 @@ h2 {
   color: #fff;
 }
 
-.movie-tabs {
+.movie-tabs,
+.shows-tabs {
   display: flex;
   gap: 4px;
   margin-bottom: 8px;
 }
 
-.movie-tab {
+.movie-tab,
+.shows-tab {
   flex: 1 1 0;
   padding: 6px;
   border: 1px solid #ccc;
@@ -2351,7 +2353,8 @@ h2 {
   cursor: pointer;
 }
 
-.movie-tab.active {
+.movie-tab.active,
+.shows-tab.active {
   background: #7aa68c;
   color: #fff;
 }


### PR DESCRIPTION
## Summary
- add sub-tab navigation within the Live Music panel for the feed and saved events view
- render interested Ticketmaster shows in a dedicated list while keeping the main feed filtered when events are dismissed
- share existing sub-tab styles so the new controls match the rest of the UI

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu' during Vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c4dbe9dc8327abbecb688c9a11b0