### PR TITLE
Fix restaurant map markers and remove hero copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,10 +130,6 @@
             <h2>Restaurants</h2>
             <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
           </div>
-      <div class="restaurants-hero">
-        <p>Discover the highest-rated spots around you, complete with a live map powered by Yelp Fusion.</p>
-        <p class="restaurants-tip">Use the map to orient yourself and tap the actions on each card to call ahead or get directions.</p>
-      </div>
       <div class="restaurants-layout">
         <div
           id="restaurantsMap"

--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -7,6 +7,19 @@ let initialized = false;
 let mapInstance = null;
 let mapMarkersLayer = null;
 
+function parseCoordinate(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : NaN;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return NaN;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }
+  return NaN;
+}
+
 function ensureMap() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return null;
   if (typeof window.L === 'undefined') return null;
@@ -201,8 +214,8 @@ function createActions(rest) {
     actions.appendChild(websiteLink);
   }
 
-  const lat = typeof rest.latitude === 'number' ? rest.latitude : Number(rest.latitude);
-  const lng = typeof rest.longitude === 'number' ? rest.longitude : Number(rest.longitude);
+  const lat = parseCoordinate(rest.latitude);
+  const lng = parseCoordinate(rest.longitude);
   let directionsHref = '';
   if (Number.isFinite(lat) && Number.isFinite(lng)) {
     directionsHref = `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`;
@@ -246,8 +259,8 @@ function updateMap(items = []) {
 
   const bounds = [];
   items.forEach(rest => {
-    const lat = typeof rest.latitude === 'number' ? rest.latitude : Number(rest.latitude);
-    const lng = typeof rest.longitude === 'number' ? rest.longitude : Number(rest.longitude);
+    const lat = parseCoordinate(rest.latitude);
+    const lng = parseCoordinate(rest.longitude);
     if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
 
     const marker = window.L.marker([lat, lng]);


### PR DESCRIPTION
## Summary
- remove the unused hero copy from the restaurants panel
- ignore blank latitude and longitude values when rendering restaurant markers so the map zooms to valid results

## Testing
- npm test *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cd5404c083278f3abf4183031c44