### PR TITLE
Add instructions for resolving recipe proxy CORS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-Narrow things down. 
+Narrow things down.
+
+## Recipe panel setup
+
+If the Recipes tab shows a CORS error when searching, the frontend could not reach the
+Spoonacular proxy. To fix this locally:
+
+1. Create a `.env` file next to `backend/server.js` with your Spoonacular API key, for example `SPOONACULAR_KEY=your_api_key_here`.
+2. Restart the development server with `npm start` so the `/api/spoonacular` endpoint becomes available with the proper CORS headers.
+3. If you are using a hosted proxy instead of the local server, assign its base URL to `window.apiBaseUrl` before the dashboard initializes.
+
+After applying one of the setups above, reload the page and try the search again.

--- a/js/recipes.js
+++ b/js/recipes.js
@@ -148,7 +148,20 @@ export async function initRecipesPanel() {
       localStorage.setItem('recipesQuery', query);
     } catch (err) {
       console.error('Failed to load recipes', err);
-      listEl.textContent = 'Failed to load recipes.';
+      const instructions = document.createElement('div');
+      instructions.className = 'recipes-error';
+      instructions.innerHTML = `
+        <p>We couldn't reach the recipes service.</p>
+        <p>To fix this locally:</p>
+        <ol>
+          <li>Create a <code>.env</code> file next to <code>backend/server.js</code> with your Spoonacular key, e.g. <code>SPOONACULAR_KEY=your_api_key_here</code>.</li>
+          <li>Restart the server with <code>npm start</code> so <code>/api/spoonacular</code> becomes available.</li>
+          <li>If you rely on a hosted proxy instead, assign its base URL to <code>window.apiBaseUrl</code> before calling <code>initRecipesPanel()</code>.</li>
+        </ol>
+        <p>After updating the configuration, try searching again.</p>
+      `;
+      listEl.innerHTML = '';
+      listEl.appendChild(instructions);
     } finally {
       if (searchBtn) searchBtn.disabled = false;
     }


### PR DESCRIPTION
## Summary
- show step-by-step guidance in the recipes panel when the Spoonacular proxy cannot be reached
- document how to configure the local proxy or hosted base URL so recipe searches avoid CORS errors

## Testing
- `npm test` *(fails: rollup optional dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ce8f90048327b3b679021eb10301