### PR TITLE
Reduce prominence of Spotify sign-in indicator

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -442,15 +442,21 @@ export async function initShowsPanel() {
     const storedToken =
       (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
     if (storedToken) {
-      if (tokenBtn) tokenBtn.textContent = 'Logged in';
-      if (statusEl) statusEl.textContent = 'Logged in';
+      if (tokenBtn) tokenBtn.textContent = 'Login to Spotify';
+      if (statusEl) {
+        statusEl.textContent = 'Signed in to Spotify';
+        statusEl.classList.add('shows-spotify-status');
+      }
       if (tokenInput) {
         tokenInput.disabled = true;
         tokenInput.style.display = 'none';
       }
     } else {
       if (tokenBtn) tokenBtn.textContent = 'Login to Spotify';
-      if (statusEl) statusEl.textContent = '';
+      if (statusEl) {
+        statusEl.textContent = '';
+        statusEl.classList.remove('shows-spotify-status');
+      }
       if (tokenInput) {
         tokenInput.disabled = false;
         tokenInput.style.display = '';

--- a/style.css
+++ b/style.css
@@ -802,6 +802,12 @@ button:hover {
   font-weight: 600;
 }
 
+#spotifyStatus,
+.shows-spotify-status {
+  font-size: 0.85rem;
+  color: #5f6368;
+}
+
 
 .goal-drop-indicator {
   outline: 2px dashed #ccc;


### PR DESCRIPTION
## Summary
- keep the Spotify connection button labeled "Login to Spotify" after authenticating
- show a subtle "Signed in to Spotify" status message beside the button and hide it when signed out
- style the status message with a smaller, muted font so it is less prominent

## Testing
- Not run (Rollup native dependency missing in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2ce671fd4832794d2ef3a0647b5ba