### PR TITLE
Fix Yelp request when coordinates available

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -185,7 +185,6 @@ app.get('/api/restaurants', async (req, res) => {
     params.delete('location');
     params.set('latitude', String(latitude));
     params.set('longitude', String(longitude));
-    params.set('location', `${latitude},${longitude}`);
   }
   if (cuisine) {
     params.set('term', String(cuisine));


### PR DESCRIPTION
## Summary
- stop appending a location string when latitude and longitude are already supplied to the Yelp search proxy
- rely on coordinate-only searches so the API can return businesses with coordinates for map markers

## Testing
- `npm test` *(fails: rollup optional dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cf9bc57c83279c0a3c5f0453b702