### PR TITLE
Handle TMDB proxy credit failures more gracefully

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -208,9 +208,18 @@ async function callTmdbProxy(endpoint, params = {}) {
     } catch (_) {
       error.body = null;
     }
-    if (response.status >= 400) {
+
+    const shouldDisableProxy = (() => {
+      if (response.status >= 500) return true;
+      if (response.status === 401 || response.status === 403) return true;
+      const bodyText = typeof error.body === 'string' ? error.body : '';
+      return bodyText.includes('tmdb_key_not_configured');
+    })();
+
+    if (shouldDisableProxy) {
       disableTmdbProxy();
     }
+
     throw error;
   }
   return response.json();


### PR DESCRIPTION
## Summary
- adjust TMDB proxy error handling so only authentication or server failures disable the proxy

## Testing
- npm test -- --run *(fails: missing optional dependency `@rollup/rollup-linux-x64-gnu` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d28137b8832785020e87942e746b