### PR TITLE
Improve recipe panel layout and metadata

### DIFF
--- a/style.css
+++ b/style.css
@@ -2776,3 +2776,215 @@ h2 {
   }
 }
 
+
+/* ------------------------------
+   Recipes Panel
+------------------------------ */
+.recipe-card-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.recipe-card-item {
+  list-style: none;
+}
+
+.recipe-card {
+  background: #ffffff;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 100%;
+}
+
+.recipe-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.recipe-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+  line-height: 1.35;
+  color: #2f2a1f;
+}
+
+.recipe-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.recipe-card__action {
+  background: #f4efe6;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.recipe-card__action:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.12);
+}
+
+.recipe-card__action:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.recipe-card__media {
+  margin: 0;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.recipe-card__image {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.recipe-card__summary {
+  margin: 0;
+  color: #544c3a;
+  line-height: 1.5;
+}
+
+.recipe-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.recipe-card__badge {
+  background: #e8f5e9;
+  color: #256029;
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.recipe-card__facts {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  margin: 0;
+}
+
+.recipe-card__fact {
+  background: #faf6ef;
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.recipe-card__fact-label {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #8c7b65;
+}
+
+.recipe-card__fact-value {
+  margin: 0;
+  font-weight: 600;
+  color: #3b3528;
+}
+
+.recipe-card__tags {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.recipe-card__tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.recipe-card__tag-label {
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: #6d5b45;
+}
+
+.recipe-card__tag {
+  background: #e7ecfa;
+  color: #2c3e7d;
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.recipe-card__section {
+  background: rgba(250, 246, 239, 0.65);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+}
+
+.recipe-card__section-title {
+  margin: 0 0 0.4rem 0;
+  font-size: 0.95rem;
+  color: #453c2f;
+}
+
+.recipe-card__ingredients,
+.recipe-card__steps {
+  margin: 0;
+  padding-left: 1.1rem;
+  line-height: 1.5;
+}
+
+.recipe-card__ingredients li,
+.recipe-card__steps li {
+  margin-bottom: 0.4rem;
+}
+
+.recipe-card__wine-list,
+.recipe-card__wine-text,
+.recipe-card__source {
+  margin: 0.4rem 0 0 0;
+  color: #544c3a;
+}
+
+.recipe-card__source a {
+  color: #2c3e7d;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.recipe-card__source a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  .recipe-card {
+    padding: 1rem;
+  }
+
+  .recipe-card__facts {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}
+


### PR DESCRIPTION
## Summary
- redesign the recipes panel to render rich recipe cards with summaries, badges, tags, and links
- expand stored recipe details so saved/hidden recipes are keyed reliably across refreshes
- add dedicated styling for the card layout and update unit tests for the new structure

## Testing
- `npm test` *(fails: cannot find optional module @rollup/rollup-linux-x64-gnu in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d2ba98d48327b8cba32a796ccb72