### PR TITLE
Improve guidance when Firebase config is missing

### DIFF
--- a/README copy.md
+++ b/README copy.md
@@ -46,3 +46,9 @@ npm test
 ### Spoonacular proxy
 
 The backend exposes a `/api/spoonacular` route that forwards recipe searches to the Spoonacular API without revealing your key. Define a `SPOONACULAR_KEY` environment variable before running the server when deploying (e.g., on Render).
+
+### Firebase configuration
+
+When the frontend loads it requests `js/firebase-config.js`. The file is ignored by Git so you can safely store your Firebase credentials there.
+If it has not been created yet the browser will log a `Missing Firebase configuration` error. To fix it, copy `js/firebase-config.example.js` to `js/firebase-config.js` and fill in the values from your Firebase project.
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -25,6 +25,23 @@ const HAS_TICKETMASTER_KEY = Boolean(TICKETMASTER_CONSUMER_KEY);
 // Enable CORS for all routes so the frontend can reach the API
 app.use(cors());
 
+// Provide a helpful response when the Firebase config file has not been created yet.
+const firebaseConfigPath = path.resolve(__dirname, '../js/firebase-config.js');
+app.get('/js/firebase-config.js', (req, res, next) => {
+  if (fs.existsSync(firebaseConfigPath)) {
+    return res.sendFile(firebaseConfigPath);
+  }
+
+  res
+    .status(404)
+    .type('application/javascript')
+    .send([
+      "console.error('Dashboard: js/firebase-config.js was requested but does not exist.');",
+      "console.error('Copy js/firebase-config.example.js to js/firebase-config.js and fill in your Firebase credentials.');",
+      "throw new Error('Missing Firebase configuration. See console for setup instructions.');"
+    ].join('\n'));
+});
+
 const CONTACT_EMAIL = Buffer.from('ZHZkbmRyc25AZ21haWwuY29t', 'base64').toString('utf8');
 const mailer = (() => {
   if (!nodemailer || !process.env.SMTP_HOST || !process.env.SMTP_USER || !process.env.SMTP_PASS) return null;


### PR DESCRIPTION
## Summary
- serve a descriptive JavaScript response when `js/firebase-config.js` has not been created yet so the browser no longer receives an HTML 404 page
- document how to provide a local Firebase configuration for development

## Testing
- npm test *(fails: tests/auth.test.js, tests/movies.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d477ffa083278a86d58d7f4869ad