### PR TITLE
Update Spotify login UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,10 +81,9 @@
             <h2>Live Music</h2>
             <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
           </div>
-          <div id="ticketmasterForm" style="margin-bottom:1rem;">
+          <div id="ticketmasterForm" style="margin-bottom:1rem;display:flex;align-items:center;gap:.5rem;">
             <button type="button" id="spotifyTokenBtn" style="margin-right:.5rem;">Login to Spotify</button>
-            <span id="spotifyStatus" style="margin-right:.5rem;"></span>
-            <input type="password" id="spotifyToken" placeholder="Spotify Access Token" style="margin-right:.5rem;">
+            <span id="spotifyStatus"></span>
             <input type="password" id="ticketmasterApiKey" placeholder="Ticketmaster API Key" style="margin-right:.5rem;">
           </div>
           <div id="showsTabs" class="movie-tabs">

--- a/js/shows.js
+++ b/js/shows.js
@@ -473,7 +473,6 @@ export async function initShowsPanel() {
   if (!listEl) return;
   const interestedListEl = document.getElementById('ticketmasterInterestedList');
   const tokenBtn = document.getElementById('spotifyTokenBtn');
-  const tokenInput = document.getElementById('spotifyToken');
   const statusEl = document.getElementById('spotifyStatus');
   const apiKeyInput = document.getElementById('ticketmasterApiKey');
   const tabsContainer = document.getElementById('showsTabs');
@@ -541,24 +540,22 @@ export async function initShowsPanel() {
     const storedToken =
       (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
     if (storedToken) {
-      if (tokenBtn) tokenBtn.textContent = 'Login to Spotify';
+      if (tokenBtn) {
+        tokenBtn.textContent = 'Login to Spotify';
+        tokenBtn.style.display = 'none';
+      }
       if (statusEl) {
         statusEl.textContent = 'Signed in to Spotify';
         statusEl.classList.add('shows-spotify-status');
       }
-      if (tokenInput) {
-        tokenInput.disabled = true;
-        tokenInput.style.display = 'none';
-      }
     } else {
-      if (tokenBtn) tokenBtn.textContent = 'Login to Spotify';
+      if (tokenBtn) {
+        tokenBtn.textContent = 'Login to Spotify';
+        tokenBtn.style.display = '';
+      }
       if (statusEl) {
         statusEl.textContent = '';
         statusEl.classList.remove('shows-spotify-status');
-      }
-      if (tokenInput) {
-        tokenInput.disabled = false;
-        tokenInput.style.display = '';
       }
     }
   };
@@ -600,7 +597,7 @@ export async function initShowsPanel() {
 
   const params = new URLSearchParams(window.location.search);
   const authCode = params.get('code');
-  if (authCode && tokenInput) {
+  if (authCode) {
     try {
       const verifier =
         (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyCodeVerifier')) || '';
@@ -619,7 +616,6 @@ export async function initShowsPanel() {
       if (res.ok) {
         const data = await res.json();
         const accessToken = data.access_token || '';
-        if (tokenInput) tokenInput.value = '';
         if (typeof localStorage !== 'undefined') {
           localStorage.setItem('spotifyToken', accessToken);
         }
@@ -634,7 +630,6 @@ export async function initShowsPanel() {
 
   const loadShows = async () => {
     const token =
-      tokenInput?.value.trim() ||
       (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
     const manualApiKey =
       apiKeyInput?.value.trim() ||
@@ -644,11 +639,6 @@ export async function initShowsPanel() {
     if (!token) {
       listEl.textContent = 'Please login to Spotify.';
       return;
-    }
-
-    if (tokenInput?.value && typeof localStorage !== 'undefined') {
-      localStorage.setItem('spotifyToken', token);
-      updateSpotifyStatus();
     }
 
     if (requiresManualApiKey && !manualApiKey) {

--- a/style.css
+++ b/style.css
@@ -802,6 +802,10 @@ button:hover {
   font-weight: 600;
 }
 
+#spotifyStatus {
+  margin-left: auto;
+}
+
 #spotifyStatus,
 .shows-spotify-status {
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- remove the manual Spotify access token input from the Live Music panel
- hide the Spotify login button once a token is present and reposition the signed-in status to the right
- adjust layout and styles so the login controls use flex alignment and the status spans the remaining space

## Testing
- `npm test` *(fails: existing auth and movies test failures in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e314b5bdd08327a927fd77fa744069