### PR TITLE
Sort recipes by score descending

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -163,6 +163,10 @@ export async function initRecipesPanel() {
               facts,
               tagGroups,
               badges,
+              score:
+                typeof r.spoonacularScore === 'number'
+                  ? r.spoonacularScore
+                  : null,
               sourceName: r.sourceName || '',
               sourceUrl: r.sourceUrl || '',
               winePairing
@@ -174,8 +178,11 @@ export async function initRecipesPanel() {
         return;
       }
       const hidden = readArray('recipesHidden').map(String);
+      const scoreValue = recipe =>
+        typeof recipe.score === 'number' ? recipe.score : -Infinity;
       const limited = recipes
         .filter(r => !hidden.includes(r.storageKey))
+        .sort((a, b) => scoreValue(b) - scoreValue(a))
         .slice(0, 10);
       if (limited.length === 0) {
         listEl.innerHTML = '<p><em>No recipes to show. Try unhiding recipes or searching again.</em></p>';


### PR DESCRIPTION
## Summary
- capture each recipe's Spoonacular score during mapping
- sort the visible recipes by score so the highest-rated options appear first

## Testing
- Not run (vitest suite fails in this environment due to missing external API configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e3156e91148327a73ff46589971525