### PR TITLE
Make restaurants map square

### DIFF
--- a/style.css
+++ b/style.css
@@ -2597,6 +2597,7 @@ h2 {
 
 .restaurants-map {
   min-height: 260px;
+  aspect-ratio: 1 / 1;
   border-radius: 18px;
   overflow: hidden;
   box-shadow: 0 12px 28px rgba(25, 55, 45, 0.12);


### PR DESCRIPTION
## Summary
- enforce a square aspect ratio for the restaurants map container so it always renders with equal width and height

## Testing
- npm test *(fails: requires external configuration and data for Firebase and TMDB)*

------
https://chatgpt.com/codex/tasks/task_e_68e3157938b483278e582e2cddd4aebf