### PR TITLE
Add similar artist suggestions when no shows are available

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -37,6 +37,10 @@ let userLocationRequested = false;
 const SHOW_PREFS_STORAGE_KEY = 'showsPreferences';
 let currentShows = [];
 let showsEmptyReason = null;
+let lastTopArtists = [];
+let similarArtistsCache = { seedKey: '', artists: null, generatedAt: 0 };
+let spotifyTokenInputRef = null;
+let updateSpotifyStatusRef = null;
 
 const TICKETMASTER_CACHE_STORAGE_KEY = 'ticketmasterCacheV1';
 const TICKETMASTER_CACHE_TTL = 1000 * 60 * 30; // 30 minutes
@@ -243,6 +247,229 @@ function getShowStatus(id) {
   return showPreferences[id]?.status || null;
 }
 
+function computeSimilarArtistsSeedKey(artistsList = lastTopArtists) {
+  return artistsList
+    .map(artist => artist?.id || artist?.name || '')
+    .filter(Boolean)
+    .join('|');
+}
+
+function getStoredSpotifyToken() {
+  return (
+    spotifyTokenInputRef?.value?.trim() ||
+    (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) ||
+    ''
+  );
+}
+
+function renderSimilarArtistsMessage(container, message) {
+  if (!container) return;
+  container.hidden = false;
+  container.innerHTML = '';
+  const messageEl = document.createElement('div');
+  messageEl.className = 'shows-suggestions__message';
+  messageEl.textContent = message;
+  container.appendChild(messageEl);
+}
+
+function renderSimilarArtistsSuggestions(container, artists) {
+  if (!container) return;
+  container.hidden = false;
+  container.innerHTML = '';
+
+  if (!Array.isArray(artists) || artists.length === 0) {
+    renderSimilarArtistsMessage(container, 'No similar artists found right now. Try again later.');
+    return;
+  }
+
+  const title = document.createElement('div');
+  title.className = 'shows-suggestions__title';
+  title.textContent = 'You might also like:';
+  container.appendChild(title);
+
+  const list = document.createElement('ul');
+  list.className = 'shows-suggestions__list';
+
+  for (const artist of artists) {
+    const item = document.createElement('li');
+    item.className = 'shows-suggestions__item';
+
+    const firstImage = artist?.images?.find(img => img?.url) || artist?.images?.[0];
+    if (firstImage?.url) {
+      const img = document.createElement('img');
+      img.src = firstImage.url;
+      img.alt = `${artist?.name || 'Artist'} photo`;
+      img.loading = 'lazy';
+      item.appendChild(img);
+    } else {
+      const avatar = document.createElement('div');
+      avatar.className = 'shows-suggestions__avatar';
+      const initial = (artist?.name || '?').trim().charAt(0).toUpperCase();
+      avatar.textContent = initial || '?';
+      item.appendChild(avatar);
+    }
+
+    const info = document.createElement('div');
+    info.className = 'shows-suggestions__info';
+
+    if (artist?.external_urls?.spotify) {
+      const link = document.createElement('a');
+      link.href = artist.external_urls.spotify;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = artist?.name || 'Unknown artist';
+      info.appendChild(link);
+    } else {
+      const nameEl = document.createElement('span');
+      nameEl.textContent = artist?.name || 'Unknown artist';
+      info.appendChild(nameEl);
+    }
+
+    const metaParts = [];
+    const genres = Array.isArray(artist?.genres) ? artist.genres.slice(0, 2) : [];
+    if (genres.length) {
+      metaParts.push(genres.join(', '));
+    }
+    if (Number.isFinite(artist?.popularity)) {
+      metaParts.push(`Popularity ${Math.round(artist.popularity)}`);
+    }
+    if (metaParts.length) {
+      const meta = document.createElement('div');
+      meta.className = 'shows-suggestions__meta';
+      meta.textContent = metaParts.join(' • ');
+      info.appendChild(meta);
+    }
+
+    item.appendChild(info);
+    list.appendChild(item);
+  }
+
+  container.appendChild(list);
+}
+
+async function fetchSimilarArtists(token, seedKey) {
+  const seeds = lastTopArtists.filter(artist => artist?.id).slice(0, 5);
+  if (!token || !seeds.length) {
+    similarArtistsCache = { seedKey, artists: null, generatedAt: 0 };
+    return [];
+  }
+
+  const suggestions = new Map();
+  const seedIds = new Set(seeds.map(seed => seed.id));
+  let unauthorized = false;
+
+  for (const seed of seeds) {
+    try {
+      const res = await fetch(`https://api.spotify.com/v1/artists/${encodeURIComponent(seed.id)}/related-artists`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (res.status === 401) {
+        unauthorized = true;
+        break;
+      }
+      if (!res.ok) {
+        continue;
+      }
+      const data = await res.json();
+      const related = Array.isArray(data?.artists) ? data.artists : [];
+      for (const artist of related) {
+        if (!artist?.id || seedIds.has(artist.id)) continue;
+        if (!suggestions.has(artist.id)) {
+          suggestions.set(artist.id, {
+            artist,
+            score: Number.isFinite(artist?.popularity) ? artist.popularity : 0
+          });
+        } else {
+          const entry = suggestions.get(artist.id);
+          const score = Number.isFinite(artist?.popularity) ? artist.popularity : 0;
+          entry.score = Math.max(entry.score, score);
+        }
+      }
+    } catch (err) {
+      console.warn('Unable to load similar artists for seed', seed?.id, err);
+    }
+  }
+
+  if (unauthorized) {
+    similarArtistsCache = { seedKey: '', artists: null, generatedAt: 0 };
+    throw new Error('unauthorized');
+  }
+
+  const result = Array.from(suggestions.values())
+    .sort((a, b) => (b.score || 0) - (a.score || 0))
+    .slice(0, 10)
+    .map(entry => entry.artist);
+
+  similarArtistsCache = { seedKey, artists: result, generatedAt: Date.now() };
+  return result;
+}
+
+async function handleSuggestSimilarArtists(button, container) {
+  if (!button || !container) return;
+
+  const defaultLabel = button.dataset.defaultLabel || 'Suggest similar artists';
+  const refreshLabel = button.dataset.refreshLabel || 'Refresh similar artist suggestions';
+  const loadingLabel = 'Finding artists…';
+
+  const token = getStoredSpotifyToken();
+  if (!token) {
+    renderSimilarArtistsMessage(
+      container,
+      'Login to Spotify above to get personalized artist suggestions.'
+    );
+    button.disabled = false;
+    button.textContent = defaultLabel;
+    return;
+  }
+
+  if (!lastTopArtists.length) {
+    renderSimilarArtistsMessage(
+      container,
+      'Start listening on Spotify so we can learn your favorite artists first.'
+    );
+    button.disabled = false;
+    button.textContent = defaultLabel;
+    return;
+  }
+
+  const seedKey = computeSimilarArtistsSeedKey();
+  if (
+    similarArtistsCache.seedKey === seedKey &&
+    Array.isArray(similarArtistsCache.artists)
+  ) {
+    renderSimilarArtistsSuggestions(container, similarArtistsCache.artists);
+    button.disabled = false;
+    button.textContent = refreshLabel;
+    return;
+  }
+
+  button.disabled = true;
+  button.textContent = loadingLabel;
+  renderSimilarArtistsMessage(container, 'Finding similar artists based on your top Spotify picks…');
+
+  try {
+    const artists = await fetchSimilarArtists(token, seedKey);
+    renderSimilarArtistsSuggestions(container, artists);
+    button.textContent = refreshLabel;
+  } catch (err) {
+    if (err?.message === 'unauthorized') {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem('spotifyToken');
+      }
+      updateSpotifyStatusRef?.();
+      renderSimilarArtistsMessage(
+        container,
+        'Spotify session expired. Please login again to refresh suggestions.'
+      );
+    } else {
+      renderSimilarArtistsMessage(container, 'Unable to load similar artists. Please try again.');
+    }
+    button.textContent = defaultLabel;
+  } finally {
+    button.disabled = false;
+  }
+}
+
 function renderShowsList() {
   const listEl = document.getElementById('ticketmasterList');
   const interestedEl = document.getElementById('ticketmasterInterestedList');
@@ -257,6 +484,9 @@ function renderShowsList() {
 
   if (!currentShows.length) {
     if (listEl) {
+      const emptyWrapper = document.createElement('div');
+      emptyWrapper.className = 'shows-empty-state';
+
       const emptyMessage =
         showsEmptyReason === 'noNearby'
           ? 'No nearby shows within 300 miles.'
@@ -264,7 +494,43 @@ function renderShowsList() {
       const emptyEl = document.createElement('p');
       emptyEl.className = 'shows-empty';
       emptyEl.textContent = emptyMessage;
-      listEl.appendChild(emptyEl);
+      emptyWrapper.appendChild(emptyEl);
+
+      const seedKey = computeSimilarArtistsSeedKey();
+      const hasCachedSuggestions =
+        similarArtistsCache.seedKey === seedKey &&
+        Array.isArray(similarArtistsCache.artists);
+
+      const actions = document.createElement('div');
+      actions.className = 'shows-empty-actions';
+
+      const suggestBtn = document.createElement('button');
+      suggestBtn.type = 'button';
+      suggestBtn.className = 'shows-empty__button';
+      suggestBtn.dataset.defaultLabel = 'Suggest similar artists';
+      suggestBtn.dataset.refreshLabel = 'Refresh similar artist suggestions';
+      suggestBtn.textContent = hasCachedSuggestions
+        ? suggestBtn.dataset.refreshLabel
+        : suggestBtn.dataset.defaultLabel;
+
+      const suggestionsContainer = document.createElement('div');
+      suggestionsContainer.className = 'shows-suggestions';
+      suggestionsContainer.hidden = !hasCachedSuggestions;
+
+      suggestBtn.addEventListener('click', () =>
+        handleSuggestSimilarArtists(suggestBtn, suggestionsContainer)
+      );
+
+      actions.appendChild(suggestBtn);
+      emptyWrapper.appendChild(actions);
+
+      if (hasCachedSuggestions && similarArtistsCache.artists) {
+        renderSimilarArtistsSuggestions(suggestionsContainer, similarArtistsCache.artists);
+      }
+
+      emptyWrapper.appendChild(suggestionsContainer);
+
+      listEl.appendChild(emptyWrapper);
     }
     if (interestedEl) {
       const emptyInterested = document.createElement('p');
@@ -478,6 +744,8 @@ export async function initShowsPanel() {
   const apiKeyInput = document.getElementById('ticketmasterApiKey');
   const tabsContainer = document.getElementById('showsTabs');
 
+  spotifyTokenInputRef = tokenInput;
+
   if (tabsContainer) {
     const tabButtons = Array.from(tabsContainer.querySelectorAll('.shows-tab'));
     const sections = new Map(
@@ -562,6 +830,8 @@ export async function initShowsPanel() {
       }
     }
   };
+
+  updateSpotifyStatusRef = updateSpotifyStatus;
 
   updateSpotifyStatus();
 
@@ -677,6 +947,11 @@ export async function initShowsPanel() {
       if (!artistRes.ok) throw new Error(`Spotify HTTP ${artistRes.status}`);
       const artistData = await artistRes.json();
       const artists = artistData.items || [];
+      const newSeedKey = computeSimilarArtistsSeedKey(artists);
+      if (similarArtistsCache.seedKey !== newSeedKey) {
+        similarArtistsCache = { seedKey: newSeedKey, artists: null, generatedAt: 0 };
+      }
+      lastTopArtists = artists;
       if (artists.length === 0) {
         listEl.textContent = 'No artists found.';
         return;
@@ -779,6 +1054,8 @@ export async function initShowsPanel() {
     } catch (err) {
       console.error('Failed to load shows', err);
       listEl.textContent = 'Failed to load shows.';
+      lastTopArtists = [];
+      similarArtistsCache = { seedKey: '', artists: null, generatedAt: 0 };
     }
   };
 

--- a/style.css
+++ b/style.css
@@ -802,6 +802,136 @@ button:hover {
   font-weight: 600;
 }
 
+.shows-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.shows-empty-state .shows-empty {
+  width: 100%;
+}
+
+.shows-empty-actions {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.shows-empty__button {
+  background: #1f4a40;
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.6rem 1.5rem;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.shows-empty__button:hover {
+  background: #163a32;
+}
+
+.shows-empty__button:focus-visible {
+  outline: 2px solid #3fa284;
+  outline-offset: 2px;
+}
+
+.shows-empty__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none;
+}
+
+.shows-suggestions {
+  background: #f7fbf9;
+  border: 1px solid #d4e6de;
+  border-radius: 12px;
+  padding: 1rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.shows-suggestions__title {
+  color: #1f4a40;
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.shows-suggestions__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shows-suggestions__item {
+  background: #fff;
+  border: 1px solid #d4e6de;
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.shows-suggestions__item img {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.shows-suggestions__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #dcefe7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #1f4a40;
+  flex-shrink: 0;
+}
+
+.shows-suggestions__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.shows-suggestions__info a {
+  color: #1f4a40;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.shows-suggestions__info a:hover {
+  text-decoration: underline;
+}
+
+.shows-suggestions__meta {
+  font-size: 0.8rem;
+  color: #5f6368;
+}
+
+.shows-suggestions__message {
+  background: #f0faf5;
+  border: 1px dashed #a4cabb;
+  border-radius: 10px;
+  padding: 0.75rem;
+  color: #1f4a40;
+  font-weight: 500;
+  text-align: center;
+}
+
 #spotifyStatus,
 .shows-spotify-status {
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- add a Spotify-driven "Suggest similar artists" action when no concerts are returned and surface cached recommendations in the empty-state view
- persist the user’s top artists for reuse and refresh cached recommendation data after each load
- style the empty-state action and recommendation list so the button and suggested artists align with the Live Music tab design

## Testing
- npm test *(fails: tests/auth.test.js, tests/movies.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e314c89bd48327b4ee55e23edde4bf