### PR TITLE
Add Eventbrite and Facebook events tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
       <div class="tabs scroll-tabs" id="tabsContainer" style="visibility:hidden;">
         <button class="tab-button active" data-target="moviesPanel">Movies</button>
         <button class="tab-button" data-target="showsPanel">Live Music</button>
+        <button class="tab-button" data-target="eventbritePanel">Eventbrite Events</button>
+        <button class="tab-button" data-target="facebookEventsPanel">Facebook Events</button>
         <button class="tab-button" data-target="recipesPanel">Recipes</button>
         <button class="tab-button" data-target="restaurantsPanel">Restaurants</button>
       </div>
@@ -97,6 +99,62 @@
           <div id="showsInterestedSection" style="display:none;">
             <div id="ticketmasterInterestedList" class="decision-container"></div>
           </div>
+        </div>
+      </div>
+
+    <!-- EVENTBRITE EVENTS PANEL -->
+      <div id="eventbritePanel" class="main-layout" style="display:none">
+        <div class="full-column">
+          <div class="panel-header">
+            <h2>Eventbrite Events</h2>
+            <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
+          </div>
+          <div id="eventbriteForm" style="margin-bottom:1rem;display:flex;flex-wrap:wrap;gap:.5rem;align-items:flex-end;">
+            <input type="password" id="eventbriteToken" placeholder="Eventbrite API Token" style="flex:1 1 220px;min-width:200px;">
+            <input type="text" id="eventbriteQuery" placeholder="Search keywords" style="flex:1 1 160px;min-width:160px;">
+            <input type="text" id="eventbriteLocation" placeholder="City or location" style="flex:1 1 160px;min-width:160px;">
+            <label style="display:flex;flex-direction:column;font-size:.85rem;gap:.25rem;">
+              Radius
+              <select id="eventbriteRadius" style="min-width:120px;">
+                <option value="10mi">10 mi</option>
+                <option value="25mi">25 mi</option>
+                <option value="50mi" selected>50 mi</option>
+                <option value="100mi">100 mi</option>
+              </select>
+            </label>
+            <button type="button" id="eventbriteSearchBtn">Search</button>
+          </div>
+          <div id="eventbriteResults" class="decision-container"></div>
+          <footer class="tmdb-notice" style="margin-top:0.75rem;">
+            Uses the <a href="https://www.eventbrite.com/platform/api" target="_blank" rel="noopener noreferrer">Eventbrite API</a>.
+          </footer>
+        </div>
+      </div>
+
+    <!-- FACEBOOK EVENTS PANEL -->
+      <div id="facebookEventsPanel" class="main-layout" style="display:none">
+        <div class="full-column">
+          <div class="panel-header">
+            <h2>Facebook Events</h2>
+            <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
+          </div>
+          <div id="facebookEventsForm" style="margin-bottom:1rem;display:flex;flex-wrap:wrap;gap:.5rem;align-items:flex-end;">
+            <input type="password" id="facebookAccessToken" placeholder="Facebook Access Token" style="flex:1 1 220px;min-width:200px;">
+            <input type="text" id="facebookPageId" placeholder="Page or Organizer ID" style="flex:1 1 200px;min-width:180px;">
+            <label style="display:flex;flex-direction:column;font-size:.85rem;gap:.25rem;">
+              Limit
+              <select id="facebookLimit" style="min-width:120px;">
+                <option value="10" selected>10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+              </select>
+            </label>
+            <button type="button" id="facebookFetchBtn">Fetch Events</button>
+          </div>
+          <div id="facebookEventsList" class="decision-container"></div>
+          <footer class="tmdb-notice" style="margin-top:0.75rem;">
+            Uses the <a href="https://developers.facebook.com/docs/graph-api/reference/page/events/" target="_blank" rel="noopener noreferrer">Facebook Graph API</a>.
+          </footer>
         </div>
       </div>
     <!-- RECIPES PANEL -->
@@ -189,6 +247,8 @@
   <script type="module" src="js/main.js"></script>
   <script type="module" src="js/movies.js"></script>
   <script type="module" src="js/shows.js"></script>
+  <script type="module" src="js/eventbrite.js"></script>
+  <script type="module" src="js/facebookEvents.js"></script>
   <script type="module" src="js/recipes.js"></script>
   <script type="module" src="js/restaurants.js"></script>
   <script type="module" src="js/weather.js"></script>

--- a/js/eventbrite.js
+++ b/js/eventbrite.js
@@ -1,0 +1,304 @@
+const STORAGE_KEYS = {
+  token: 'eventbriteApiToken',
+  query: 'eventbriteQuery',
+  location: 'eventbriteLocation',
+  radius: 'eventbriteRadius'
+};
+
+let initialized = false;
+let autoLoaded = false;
+let currentAbortController = null;
+
+function readStorage(key) {
+  if (typeof localStorage === 'undefined') return '';
+  try {
+    return localStorage.getItem(key) || '';
+  } catch (err) {
+    console.warn('Unable to read storage', err);
+    return '';
+  }
+}
+
+function writeStorage(key, value) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    if (value) {
+      localStorage.setItem(key, value);
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch (err) {
+    console.warn('Unable to persist storage', err);
+  }
+}
+
+function truncate(text, maxLength = 240) {
+  if (!text) return '';
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxLength) return clean;
+  return `${clean.slice(0, maxLength - 1).trim()}…`;
+}
+
+function formatDate(start) {
+  const iso = start?.local || start?.utc;
+  if (!iso) return 'Date to be announced';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(date);
+  } catch (err) {
+    console.warn('Unable to format Eventbrite date', err);
+    return date.toLocaleString();
+  }
+}
+
+function formatVenue(venue, onlineEvent) {
+  const parts = [];
+  if (venue?.name) parts.push(venue.name);
+  const address =
+    venue?.address?.localized_address_display ||
+    [venue?.address?.city, venue?.address?.region]
+      .filter(Boolean)
+      .join(', ');
+  if (address) parts.push(address);
+  if (onlineEvent) parts.push('Online event');
+  return parts.join(' • ');
+}
+
+function createActionLink(text, url) {
+  const link = document.createElement('a');
+  link.href = url;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.textContent = text;
+  link.style.display = 'inline-flex';
+  link.style.alignItems = 'center';
+  link.style.gap = '4px';
+  link.style.fontWeight = '600';
+  link.style.color = '#1b6b44';
+  return link;
+}
+
+function renderEvents(listEl, events) {
+  listEl.innerHTML = '';
+  if (!events.length) {
+    listEl.innerHTML = '<p><em>No events found. Try a different search.</em></p>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  events.forEach(event => {
+    const card = document.createElement('article');
+    card.className = 'decision-card';
+
+    const title = document.createElement('h3');
+    title.className = 'decision-title';
+    title.textContent = event?.name?.text || 'Untitled event';
+    card.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.style.fontSize = '0.9rem';
+    meta.style.marginBottom = '0.35rem';
+    const metaParts = [];
+    metaParts.push(formatDate(event?.start));
+    const venueText = formatVenue(event?.venue, event?.online_event);
+    if (venueText) metaParts.push(venueText);
+    if (typeof event?.is_free === 'boolean') {
+      metaParts.push(event.is_free ? 'Free' : 'Paid');
+    }
+    if (event?.status && event.status !== 'live') {
+      metaParts.push(`Status: ${event.status}`);
+    }
+    meta.textContent = metaParts.filter(Boolean).join(' • ');
+    card.appendChild(meta);
+
+    const description = truncate(event?.description?.text || '');
+    if (description) {
+      const descEl = document.createElement('p');
+      descEl.textContent = description;
+      descEl.style.marginBottom = '0.5rem';
+      card.appendChild(descEl);
+    }
+
+    const footer = document.createElement('div');
+    footer.className = 'button-row';
+    footer.style.flexWrap = 'wrap';
+    footer.style.gap = '8px';
+
+    if (event?.url) {
+      footer.appendChild(createActionLink('View on Eventbrite', event.url));
+    }
+
+    if (event?.venue?.name && event?.venue?.address?.localized_address_display) {
+      const encoded = encodeURIComponent(event.venue.address.localized_address_display);
+      footer.appendChild(
+        createActionLink(
+          'Open in Maps',
+          `https://www.google.com/maps/search/?api=1&query=${encoded}`
+        )
+      );
+    }
+
+    if (footer.children.length) {
+      card.appendChild(footer);
+    }
+
+    fragment.appendChild(card);
+  });
+
+  listEl.appendChild(fragment);
+}
+
+function showMessage(listEl, message) {
+  listEl.innerHTML = `<p><em>${message}</em></p>`;
+}
+
+async function fetchEvents({ token, query, location, radius }) {
+  if (!token) {
+    throw new Error('Please provide an Eventbrite API token.');
+  }
+
+  if (!query && !location) {
+    throw new Error('Enter keywords or a location to search events.');
+  }
+
+  if (currentAbortController) {
+    currentAbortController.abort();
+  }
+  const controller = new AbortController();
+  currentAbortController = controller;
+
+  const params = new URLSearchParams();
+  params.set('sort_by', 'date');
+  params.set('expand', 'venue');
+  params.set('start_date.range_start', new Date().toISOString());
+  if (query) params.set('q', query);
+  if (location) {
+    params.set('location.address', location);
+    if (radius) params.set('location.within', radius);
+  }
+
+  try {
+    const response = await fetch(
+      `https://www.eventbriteapi.com/v3/events/search/?${params.toString()}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`
+        },
+        signal: controller.signal
+      }
+    );
+
+    if (!response.ok) {
+      let message = `Eventbrite request failed with status ${response.status}`;
+      try {
+        const errorBody = await response.json();
+        if (errorBody?.error_description) {
+          message = errorBody.error_description;
+        } else if (Array.isArray(errorBody?.error?.error_detail)) {
+          message = errorBody.error.error_detail.join(', ');
+        } else if (typeof errorBody?.error === 'string') {
+          message = errorBody.error;
+        }
+      } catch (err) {
+        // ignore parsing errors
+      }
+      throw new Error(message);
+    }
+
+    const data = await response.json();
+    return Array.isArray(data?.events) ? data.events : [];
+  } finally {
+    if (currentAbortController === controller) {
+      currentAbortController = null;
+    }
+  }
+}
+
+export async function initEventbritePanel() {
+  const listEl = document.getElementById('eventbriteResults');
+  if (!listEl) return;
+
+  const tokenInput = document.getElementById('eventbriteToken');
+  const queryInput = document.getElementById('eventbriteQuery');
+  const locationInput = document.getElementById('eventbriteLocation');
+  const radiusSelect = document.getElementById('eventbriteRadius');
+  const searchBtn = document.getElementById('eventbriteSearchBtn');
+
+  if (!initialized) {
+    if (tokenInput) tokenInput.value = readStorage(STORAGE_KEYS.token);
+    if (queryInput) queryInput.value = readStorage(STORAGE_KEYS.query);
+    if (locationInput) locationInput.value = readStorage(STORAGE_KEYS.location);
+    if (radiusSelect) {
+      const storedRadius = readStorage(STORAGE_KEYS.radius);
+      if (storedRadius) radiusSelect.value = storedRadius;
+    }
+
+    const triggerSearch = async () => {
+      const token = tokenInput?.value.trim();
+      const query = queryInput?.value.trim();
+      const location = locationInput?.value.trim();
+      const radius = radiusSelect?.value || '';
+
+      writeStorage(STORAGE_KEYS.token, token);
+      writeStorage(STORAGE_KEYS.query, query);
+      writeStorage(STORAGE_KEYS.location, location);
+      writeStorage(STORAGE_KEYS.radius, radius);
+
+      showMessage(listEl, 'Loading events…');
+      try {
+        const events = await fetchEvents({ token, query, location, radius });
+        renderEvents(listEl, events);
+      } catch (err) {
+        if (err?.name === 'AbortError') {
+          return;
+        }
+        console.error('Unable to load Eventbrite events', err);
+        showMessage(listEl, err.message || 'Unable to load events.');
+      }
+    };
+
+    const handleEnter = event => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        triggerSearch();
+      }
+    };
+
+    queryInput?.addEventListener('keydown', handleEnter);
+    locationInput?.addEventListener('keydown', handleEnter);
+    tokenInput?.addEventListener('keydown', handleEnter);
+    radiusSelect?.addEventListener('change', () => {
+      writeStorage(STORAGE_KEYS.radius, radiusSelect.value);
+    });
+
+    if (searchBtn) {
+      searchBtn.addEventListener('click', triggerSearch);
+    }
+
+    initialized = true;
+  }
+
+  if (!autoLoaded) {
+    const token = tokenInput?.value.trim();
+    const query = queryInput?.value.trim();
+    const location = locationInput?.value.trim();
+
+    if (token && (query || location)) {
+      autoLoaded = true;
+      searchBtn?.click();
+    } else if (!listEl.innerHTML.trim()) {
+      showMessage(
+        listEl,
+        'Enter an API token plus keywords or a location to discover Eventbrite events.'
+      );
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.initEventbritePanel = initEventbritePanel;
+}

--- a/js/facebookEvents.js
+++ b/js/facebookEvents.js
@@ -1,0 +1,319 @@
+const STORAGE_KEYS = {
+  token: 'facebookAccessToken',
+  pageId: 'facebookPageId',
+  limit: 'facebookEventLimit'
+};
+
+let initialized = false;
+let autoLoaded = false;
+let currentAbortController = null;
+
+function readStorage(key) {
+  if (typeof localStorage === 'undefined') return '';
+  try {
+    return localStorage.getItem(key) || '';
+  } catch (err) {
+    console.warn('Unable to read storage', err);
+    return '';
+  }
+}
+
+function writeStorage(key, value) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    if (value) {
+      localStorage.setItem(key, value);
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch (err) {
+    console.warn('Unable to persist storage', err);
+  }
+}
+
+function truncate(text, maxLength = 240) {
+  if (!text) return '';
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxLength) return clean;
+  return `${clean.slice(0, maxLength - 1).trim()}…`;
+}
+
+function formatDate(iso) {
+  if (!iso) return 'Date to be announced';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(date);
+  } catch (err) {
+    console.warn('Unable to format Facebook date', err);
+    return date.toLocaleString();
+  }
+}
+
+function formatLocation(place, onlineEvent) {
+  const parts = [];
+  if (place?.name) parts.push(place.name);
+  const location = place?.location;
+  if (location) {
+    const segments = [location.city, location.state || location.region, location.country]
+      .filter(Boolean)
+      .join(', ');
+    if (segments) parts.push(segments);
+  }
+  if (onlineEvent) parts.push('Online event');
+  return parts.join(' • ');
+}
+
+function createActionLink(text, url) {
+  const link = document.createElement('a');
+  link.href = url;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.textContent = text;
+  link.style.display = 'inline-flex';
+  link.style.alignItems = 'center';
+  link.style.gap = '4px';
+  link.style.fontWeight = '600';
+  link.style.color = '#1b6b44';
+  return link;
+}
+
+function renderEvents(listEl, events) {
+  listEl.innerHTML = '';
+  if (!events.length) {
+    listEl.innerHTML = '<p><em>No events found for this page. Try another ID or increase the limit.</em></p>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  events.forEach(event => {
+    const card = document.createElement('article');
+    card.className = 'decision-card';
+
+    const title = document.createElement('h3');
+    title.className = 'decision-title';
+    title.textContent = event?.name || 'Untitled event';
+    card.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.style.fontSize = '0.9rem';
+    meta.style.marginBottom = '0.35rem';
+    const metaParts = [];
+    metaParts.push(formatDate(event?.start_time));
+    const locationText = formatLocation(event?.place, event?.online_event);
+    if (locationText) metaParts.push(locationText);
+    if (event?.is_canceled) metaParts.push('Canceled');
+    meta.textContent = metaParts.filter(Boolean).join(' • ');
+    card.appendChild(meta);
+
+    const description = truncate(event?.description || '');
+    if (description) {
+      const descEl = document.createElement('p');
+      descEl.textContent = description;
+      descEl.style.marginBottom = '0.5rem';
+      card.appendChild(descEl);
+    }
+
+    if (Array.isArray(event?.event_times) && event.event_times.length) {
+      const occurrences = document.createElement('ul');
+      occurrences.style.margin = '0 0 0.5rem 1.25rem';
+      occurrences.style.fontSize = '0.9rem';
+      const upcoming = event.event_times.slice(0, 3);
+      upcoming.forEach(time => {
+        const item = document.createElement('li');
+        item.textContent = `${formatDate(time.start_time)}${time.end_time ? ` – ${formatDate(time.end_time)}` : ''}`;
+        occurrences.appendChild(item);
+      });
+      if (event.event_times.length > upcoming.length) {
+        const more = document.createElement('li');
+        more.textContent = `+ ${event.event_times.length - upcoming.length} more occurrence(s)`;
+        occurrences.appendChild(more);
+      }
+      card.appendChild(occurrences);
+    }
+
+    const stats = [];
+    if (typeof event?.interested_count === 'number') {
+      stats.push(`${event.interested_count.toLocaleString()} interested`);
+    }
+    if (typeof event?.attending_count === 'number') {
+      stats.push(`${event.attending_count.toLocaleString()} going`);
+    }
+    if (typeof event?.maybe_count === 'number') {
+      stats.push(`${event.maybe_count.toLocaleString()} maybe`);
+    }
+    if (stats.length) {
+      const statsEl = document.createElement('div');
+      statsEl.style.fontSize = '0.85rem';
+      statsEl.style.marginBottom = '0.5rem';
+      statsEl.textContent = stats.join(' • ');
+      card.appendChild(statsEl);
+    }
+
+    const footer = document.createElement('div');
+    footer.className = 'button-row';
+    footer.style.flexWrap = 'wrap';
+    footer.style.gap = '8px';
+
+    if (event?.id) {
+      footer.appendChild(createActionLink('View on Facebook', `https://www.facebook.com/events/${event.id}`));
+    }
+    if (event?.ticket_uri) {
+      footer.appendChild(createActionLink('Tickets', event.ticket_uri));
+    }
+    if (event?.place?.location?.latitude && event?.place?.location?.longitude) {
+      const { latitude, longitude } = event.place.location;
+      const mapUrl = `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`;
+      footer.appendChild(createActionLink('Open in Maps', mapUrl));
+    }
+
+    if (footer.children.length) {
+      card.appendChild(footer);
+    }
+
+    fragment.appendChild(card);
+  });
+
+  listEl.appendChild(fragment);
+}
+
+function showMessage(listEl, message) {
+  listEl.innerHTML = `<p><em>${message}</em></p>`;
+}
+
+async function fetchFacebookEvents({ token, pageId, limit }) {
+  if (!token) {
+    throw new Error('Please provide a Facebook access token.');
+  }
+  if (!pageId) {
+    throw new Error('Enter a Page or organizer ID to load events.');
+  }
+
+  if (currentAbortController) {
+    currentAbortController.abort();
+  }
+  const controller = new AbortController();
+  currentAbortController = controller;
+
+  const version = 'v19.0';
+  const endpoint = `https://graph.facebook.com/${version}/${encodeURIComponent(pageId)}/events`;
+  const url = new URL(endpoint);
+  url.searchParams.set('access_token', token);
+  url.searchParams.set('time_filter', 'upcoming');
+  url.searchParams.set('limit', String(limit || 10));
+  url.searchParams.set(
+    'fields',
+    [
+      'name',
+      'start_time',
+      'end_time',
+      'place',
+      'description',
+      'online_event',
+      'event_times',
+      'ticket_uri',
+      'is_canceled',
+      'interested_count',
+      'maybe_count',
+      'attending_count',
+      'cover'
+    ].join(',')
+  );
+
+  try {
+    const response = await fetch(url.toString(), { signal: controller.signal });
+    const data = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      const message = data?.error?.message || `Facebook request failed with status ${response.status}`;
+      throw new Error(message);
+    }
+
+    return Array.isArray(data?.data) ? data.data : [];
+  } finally {
+    if (currentAbortController === controller) {
+      currentAbortController = null;
+    }
+  }
+}
+
+export async function initFacebookEventsPanel() {
+  const listEl = document.getElementById('facebookEventsList');
+  if (!listEl) return;
+
+  const tokenInput = document.getElementById('facebookAccessToken');
+  const pageIdInput = document.getElementById('facebookPageId');
+  const limitSelect = document.getElementById('facebookLimit');
+  const fetchBtn = document.getElementById('facebookFetchBtn');
+
+  if (!initialized) {
+    if (tokenInput) tokenInput.value = readStorage(STORAGE_KEYS.token);
+    if (pageIdInput) pageIdInput.value = readStorage(STORAGE_KEYS.pageId);
+    if (limitSelect) {
+      const storedLimit = readStorage(STORAGE_KEYS.limit);
+      if (storedLimit) limitSelect.value = storedLimit;
+    }
+
+    const triggerFetch = async () => {
+      const token = tokenInput?.value.trim();
+      const pageId = pageIdInput?.value.trim();
+      const limit = limitSelect?.value || '10';
+
+      writeStorage(STORAGE_KEYS.token, token);
+      writeStorage(STORAGE_KEYS.pageId, pageId);
+      writeStorage(STORAGE_KEYS.limit, limit);
+
+      showMessage(listEl, 'Loading events…');
+      try {
+        const events = await fetchFacebookEvents({ token, pageId, limit });
+        renderEvents(listEl, events);
+      } catch (err) {
+        if (err?.name === 'AbortError') {
+          return;
+        }
+        console.error('Unable to load Facebook events', err);
+        showMessage(listEl, err.message || 'Unable to load Facebook events.');
+      }
+    };
+
+    const handleEnter = event => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        triggerFetch();
+      }
+    };
+
+    tokenInput?.addEventListener('keydown', handleEnter);
+    pageIdInput?.addEventListener('keydown', handleEnter);
+    limitSelect?.addEventListener('change', () => {
+      writeStorage(STORAGE_KEYS.limit, limitSelect.value);
+    });
+
+    if (fetchBtn) {
+      fetchBtn.addEventListener('click', triggerFetch);
+    }
+
+    initialized = true;
+  }
+
+  if (!autoLoaded) {
+    const token = tokenInput?.value.trim();
+    const pageId = pageIdInput?.value.trim();
+    if (token && pageId) {
+      autoLoaded = true;
+      fetchBtn?.click();
+    } else if (!listEl.innerHTML.trim()) {
+      showMessage(
+        listEl,
+        'Enter an access token and Facebook Page ID to load upcoming events.'
+      );
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.initFacebookEventsPanel = initFacebookEventsPanel;
+}

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -27,6 +27,8 @@ function ensureRestaurantsPanelInitialized() {
 export const PANELS = [
   'moviesPanel',
   'showsPanel',
+  'eventbritePanel',
+  'facebookEventsPanel',
   'recipesPanel',
   'restaurantsPanel'
 ];
@@ -34,6 +36,8 @@ export const PANELS = [
 export const PANEL_NAMES = {
   moviesPanel: 'Movies',
   showsPanel: 'Live Music',
+  eventbritePanel: 'Eventbrite Events',
+  facebookEventsPanel: 'Facebook Events',
   recipesPanel: 'Recipes',
   restaurantsPanel: 'Restaurants'
 };
@@ -94,6 +98,12 @@ export async function initTabs(user, db) {
       else if (target === 'showsPanel') {
         await window.initShowsPanel();
       }
+      else if (target === 'eventbritePanel' && typeof window.initEventbritePanel === 'function') {
+        await window.initEventbritePanel();
+      }
+      else if (target === 'facebookEventsPanel' && typeof window.initFacebookEventsPanel === 'function') {
+        await window.initFacebookEventsPanel();
+      }
       else if (target === 'recipesPanel') {
         await window.initRecipesPanel();
       }
@@ -130,6 +140,12 @@ export async function initTabs(user, db) {
     }
     else if (initial === 'showsPanel') {
       window.initShowsPanel();
+    }
+    else if (initial === 'eventbritePanel' && typeof window.initEventbritePanel === 'function') {
+      window.initEventbritePanel();
+    }
+    else if (initial === 'facebookEventsPanel' && typeof window.initFacebookEventsPanel === 'function') {
+      window.initFacebookEventsPanel();
     }
     else if (initial === 'recipesPanel') {
       window.initRecipesPanel();


### PR DESCRIPTION
## Summary
- add Eventbrite and Facebook event tabs with API token inputs and usage notices
- implement Eventbrite and Facebook integrations that fetch and render events with local storage helpers and error handling
- update the tab registry so the dashboard can initialize the new panels

## Testing
- npm test *(fails: suite expects Firebase configuration and TMDB proxy credentials that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3162a1a64832785ef67310d850168