### PR TITLE
Fix syntax error in tabs panel initialization

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -105,6 +105,7 @@ export async function initTabs(user, db) {
       }
       else if (target === 'facebookEventsPanel' && typeof window.initFacebookEventsPanel === 'function') {
         await window.initFacebookEventsPanel();
+      }
       else if (target === 'comedyPanel') {
         await window.initComedyPanel();
       }
@@ -150,6 +151,7 @@ export async function initTabs(user, db) {
     }
     else if (initial === 'facebookEventsPanel' && typeof window.initFacebookEventsPanel === 'function') {
       window.initFacebookEventsPanel();
+    }
     else if (initial === 'comedyPanel') {
       window.initComedyPanel();
     }


### PR DESCRIPTION
## Summary
- close the facebook events conditional blocks in tabs.js to resolve the syntax error reported in the browser

## Testing
- npm test *(fails: existing suite requires external configuration such as Firebase credentials and mocked inputs for Spotify/Ticketmaster)*

------
https://chatgpt.com/codex/tasks/task_e_68e319847bd483278aa2c971ad3f8061