### PR TITLE
Improve TMDB proxy compatibility and tests

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -9,14 +9,22 @@ const ALLOWED_ENDPOINTS = {
   genres: { path: '/3/genre/movie/list' },
   credits: {
     path: query => {
-      const rawId = query?.movie_id;
+      if (!query || typeof query !== 'object') return null;
+      const idKeys = ['movie_id', 'movieId', 'id'];
+      let rawId;
+      for (const key of idKeys) {
+        if (Object.prototype.hasOwnProperty.call(query, key)) {
+          rawId = query[key];
+          break;
+        }
+      }
       const value = Array.isArray(rawId) ? rawId[0] : rawId;
       if (!value && value !== 0) return null;
       const trimmed = String(value).trim();
       if (!trimmed) return null;
       return `/3/movie/${encodeURIComponent(trimmed)}/credits`;
     },
-    omitParams: ['movie_id']
+    omitParams: ['movie_id', 'movieId', 'id']
   }
 };
 

--- a/js/movies.js
+++ b/js/movies.js
@@ -307,7 +307,7 @@ async function fetchCreditsForMovie(movieId, { usingProxy, apiKey }) {
   if (!movieId) return null;
   try {
     if (usingProxy) {
-      return await callTmdbProxy('credits', { movie_id: movieId });
+      return await callTmdbProxy('credits', { movieId: movieId });
     }
 
     if (!apiKey) return null;
@@ -628,7 +628,7 @@ function selectPriorityCandidates(movies) {
     if (filtered.length >= MIN_PRIORITY_RESULTS) {
       return filtered;
     }
-    if (filtered.length > bestFallback.length) {
+    if (!bestFallback.length && filtered.length) {
       bestFallback = filtered;
     }
   }


### PR DESCRIPTION
## Summary
- allow the Cloud Function TMDB proxy to accept multiple movie ID parameter names and drop them from upstream requests
- request credits through the proxy with the camelCase movieId parameter and prefer higher-quality candidates when prioritizing movies
- make the movies Vitest helpers resilient to additional fetches and assert the new proxy parameter in the proxy routing test

## Testing
- npm test -- --run tests/movies.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e31855a2288327af7ae5cfbb3e8b1a