### PR TITLE
Prevent duplicate firebaseConfig declaration

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -39,17 +39,17 @@ const firebaseConfig = (() => {
     }
   }
 
-  throw new Error('Firebase configuration was not provided. Ensure js/firebase-config.js defines window.__FIREBASE_CONFIG__.');
+  console.warn('Firebase configuration was not provided via globals or meta tags; falling back to bundled configuration.');
+  return {
+    apiKey: "AIzaSyBbet_bmwm8h8G5CqvmzrdAnc3AO-0IKa8",
+    authDomain: "decision-maker-4e1d3.firebaseapp.com",
+    projectId: "decision-maker-4e1d3",
+    storageBucket: "decision-maker-4e1d3.firebasestorage.app",
+    messagingSenderId: "727689864651",
+    appId: "1:727689864651:web:0100c3894790b8c188c24e",
+    measurementId: "G-7EJVQN0WT3"
+  };
 })();
-const firebaseConfig = {
-  apiKey: "AIzaSyBbet_bmwm8h8G5CqvmzrdAnc3AO-0IKa8",
-  authDomain: "decision-maker-4e1d3.firebaseapp.com",
-  projectId: "decision-maker-4e1d3",
-  storageBucket: "decision-maker-4e1d3.firebasestorage.app",
-  messagingSenderId: "727689864651",
-  appId: "1:727689864651:web:0100c3894790b8c188c24e",
-  measurementId: "G-7EJVQN0WT3"
-};
 
 firebase.initializeApp(firebaseConfig);
 export const auth = firebase.auth();


### PR DESCRIPTION
## Summary
- resolve firebaseConfig by reading globals or meta tag before falling back to bundled credentials
- remove duplicate constant declaration that caused SyntaxError
- log a warning when the bundled config is used as a fallback

## Testing
- vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e31b5c018483278910027b11a7814d