### PR TITLE
Prevent fetching Facebook events without required fields

### DIFF
--- a/js/facebookEvents.js
+++ b/js/facebookEvents.js
@@ -262,6 +262,16 @@ export async function initFacebookEventsPanel() {
       const pageId = pageIdInput?.value.trim();
       const limit = limitSelect?.value || '10';
 
+      if (!token) {
+        showMessage(listEl, 'Enter a Facebook access token to load events.');
+        return;
+      }
+
+      if (!pageId) {
+        showMessage(listEl, 'Enter a Page or organizer ID to load events.');
+        return;
+      }
+
       writeStorage(STORAGE_KEYS.token, token);
       writeStorage(STORAGE_KEYS.pageId, pageId);
       writeStorage(STORAGE_KEYS.limit, limit);


### PR DESCRIPTION
## Summary
- stop the Facebook events panel from firing a fetch when the token or page ID inputs are empty
- surface a friendly message immediately instead of logging validation errors to the console

## Testing
- vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e31e0843bc832785f88f6f6d319767