### PR TITLE
Add offline demos for recipes and restaurants tabs

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -84,6 +84,439 @@ const buildBadges = r => {
     .map(([label]) => label);
 };
 
+const normalizeRecipe = r => {
+  if (!r || typeof r !== 'object') return null;
+
+  const instructions = Array.isArray(r.analyzedInstructions)
+    ? r.analyzedInstructions
+        .flatMap(instruction => instruction?.steps || [])
+        .map(step => step?.step?.trim())
+        .filter(Boolean)
+    : [];
+
+  const ingredients = Array.isArray(r.extendedIngredients)
+    ? r.extendedIngredients
+        .map(ing => ing?.original || ing?.name || '')
+        .map(text => stripHtml(text))
+        .filter(Boolean)
+    : [];
+
+  const summary = stripHtml(r.summary);
+  const facts = buildFactEntries(r);
+  const tagGroups = buildTagGroups(r);
+  const badges = buildBadges(r);
+  const winePairing = {
+    wines: Array.isArray(r.winePairing?.pairedWines)
+      ? r.winePairing.pairedWines.filter(Boolean)
+      : [],
+    text: stripHtml(r.winePairing?.pairingText)
+  };
+
+  const storage = {
+    id: r.id ?? null,
+    title: r.title || 'Untitled',
+    sourceUrl: r.sourceUrl || ''
+  };
+  const storageKey = toUniqueKey(storage);
+
+  return {
+    storage,
+    storageKey,
+    title: r.title || 'Untitled',
+    image: r.image || '',
+    summary,
+    ingredients,
+    instructions,
+    facts,
+    tagGroups,
+    badges,
+    score:
+      typeof r.spoonacularScore === 'number'
+        ? r.spoonacularScore
+        : typeof r.score === 'number'
+          ? r.score
+          : null,
+    sourceName: r.sourceName || '',
+    sourceUrl: r.sourceUrl || '',
+    winePairing
+  };
+};
+
+function renderRecipeCards(listEl, recipes, options = {}) {
+  if (!listEl) return;
+
+  const {
+    noticeContent = '',
+    noticeClass = 'recipes-demo-notice',
+    onReload
+  } = options;
+
+  if (!recipes.length) {
+    listEl.innerHTML = '<p><em>No recipes to show. Try unhiding recipes or searching again.</em></p>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  if (noticeContent) {
+    const notice = document.createElement('div');
+    notice.className = noticeClass;
+    notice.innerHTML = noticeContent;
+    fragment.appendChild(notice);
+  }
+
+  const ul = document.createElement('ul');
+  ul.className = 'recipe-card-list';
+
+  recipes.forEach(recipe => {
+    const li = document.createElement('li');
+    li.className = 'recipe-card-item';
+
+    const card = document.createElement('article');
+    card.className = 'recipe-card';
+
+    const header = document.createElement('header');
+    header.className = 'recipe-card__header';
+
+    const title = document.createElement('h3');
+    title.className = 'recipe-card__title';
+    title.textContent = recipe.title;
+    header.appendChild(title);
+
+    const actions = document.createElement('div');
+    actions.className = 'recipe-card__actions';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'recipe-card__action';
+    saveBtn.textContent = 'Save';
+    if (
+      readArray('recipesSaved').some(savedRecipe => {
+        const savedKey = toUniqueKey(savedRecipe);
+        return savedKey === recipe.storageKey;
+      })
+    ) {
+      saveBtn.textContent = 'Saved';
+      saveBtn.disabled = true;
+    }
+    saveBtn.addEventListener('click', () => {
+      const saved = readArray('recipesSaved');
+      if (
+        !saved.some(savedRecipe => {
+          const savedKey = toUniqueKey(savedRecipe);
+          return savedKey === recipe.storageKey;
+        })
+      ) {
+        saved.push(recipe.storage);
+        writeArray('recipesSaved', saved);
+      }
+      saveBtn.textContent = 'Saved';
+      saveBtn.disabled = true;
+    });
+    actions.appendChild(saveBtn);
+
+    const hideBtn = document.createElement('button');
+    hideBtn.className = 'recipe-card__action';
+    hideBtn.textContent = 'Hide';
+    hideBtn.addEventListener('click', () => {
+      const stored = readArray('recipesHidden').map(String);
+      if (!stored.includes(recipe.storageKey)) {
+        stored.push(recipe.storageKey);
+        writeArray('recipesHidden', stored);
+      }
+      li.remove();
+      if (!document.querySelector('#recipesList .recipe-card-item')) {
+        if (typeof onReload === 'function') {
+          onReload();
+        } else {
+          listEl.innerHTML = '<p><em>No recipes to show. Try unhiding recipes or searching again.</em></p>';
+        }
+      }
+    });
+    actions.appendChild(hideBtn);
+
+    header.appendChild(actions);
+    card.appendChild(header);
+
+    if (recipe.image) {
+      const figure = document.createElement('figure');
+      figure.className = 'recipe-card__media';
+      const img = document.createElement('img');
+      img.className = 'recipe-card__image';
+      img.src = recipe.image;
+      img.alt = `${recipe.title} photo`;
+      figure.appendChild(img);
+      card.appendChild(figure);
+    }
+
+    if (recipe.summary) {
+      const summary = document.createElement('p');
+      summary.className = 'recipe-card__summary';
+      summary.textContent = recipe.summary;
+      card.appendChild(summary);
+    }
+
+    if (recipe.badges.length) {
+      const badgeWrap = document.createElement('div');
+      badgeWrap.className = 'recipe-card__badges';
+      recipe.badges.forEach(label => {
+        const badge = document.createElement('span');
+        badge.className = 'recipe-card__badge';
+        badge.textContent = label;
+        badgeWrap.appendChild(badge);
+      });
+      card.appendChild(badgeWrap);
+    }
+
+    if (recipe.facts.length) {
+      const facts = document.createElement('dl');
+      facts.className = 'recipe-card__facts';
+      recipe.facts.forEach(([label, value]) => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'recipe-card__fact';
+        const factLabel = document.createElement('dt');
+        factLabel.className = 'recipe-card__fact-label';
+        factLabel.textContent = label;
+        const factValue = document.createElement('dd');
+        factValue.className = 'recipe-card__fact-value';
+        factValue.textContent = value;
+        wrapper.appendChild(factLabel);
+        wrapper.appendChild(factValue);
+        facts.appendChild(wrapper);
+      });
+      card.appendChild(facts);
+    }
+
+    if (recipe.tagGroups.length) {
+      const tagSection = document.createElement('div');
+      tagSection.className = 'recipe-card__tags';
+      recipe.tagGroups.forEach(group => {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'recipe-card__tag-group';
+        const groupLabel = document.createElement('span');
+        groupLabel.className = 'recipe-card__tag-label';
+        groupLabel.textContent = group.label;
+        groupEl.appendChild(groupLabel);
+        group.items.forEach(item => {
+          const chip = document.createElement('span');
+          chip.className = 'recipe-card__tag';
+          chip.textContent = item;
+          groupEl.appendChild(chip);
+        });
+        tagSection.appendChild(groupEl);
+      });
+      card.appendChild(tagSection);
+    }
+
+    if (recipe.ingredients.length) {
+      const section = document.createElement('section');
+      section.className = 'recipe-card__section';
+      const heading = document.createElement('h4');
+      heading.className = 'recipe-card__section-title';
+      heading.textContent = 'Ingredients';
+      section.appendChild(heading);
+      const list = document.createElement('ul');
+      list.className = 'recipe-card__ingredients';
+      recipe.ingredients.forEach(item => {
+        const ingItem = document.createElement('li');
+        ingItem.textContent = item;
+        list.appendChild(ingItem);
+      });
+      section.appendChild(list);
+      card.appendChild(section);
+    }
+
+    if (recipe.instructions.length) {
+      const section = document.createElement('section');
+      section.className = 'recipe-card__section';
+      const heading = document.createElement('h4');
+      heading.className = 'recipe-card__section-title';
+      heading.textContent = 'Instructions';
+      section.appendChild(heading);
+      const list = document.createElement('ol');
+      list.className = 'recipe-card__steps';
+      recipe.instructions.forEach(step => {
+        const stepItem = document.createElement('li');
+        stepItem.textContent = step;
+        list.appendChild(stepItem);
+      });
+      section.appendChild(list);
+      card.appendChild(section);
+    }
+
+    if (recipe.winePairing.wines.length || recipe.winePairing.text) {
+      const section = document.createElement('section');
+      section.className = 'recipe-card__section';
+      const heading = document.createElement('h4');
+      heading.className = 'recipe-card__section-title';
+      heading.textContent = 'Wine pairing';
+      section.appendChild(heading);
+      if (recipe.winePairing.wines.length) {
+        const wines = document.createElement('p');
+        wines.className = 'recipe-card__wine-list';
+        wines.textContent = recipe.winePairing.wines.join(', ');
+        section.appendChild(wines);
+      }
+      if (recipe.winePairing.text) {
+        const details = document.createElement('p');
+        details.className = 'recipe-card__wine-text';
+        details.textContent = recipe.winePairing.text;
+        section.appendChild(details);
+      }
+      card.appendChild(section);
+    }
+
+    if (recipe.sourceUrl) {
+      const source = document.createElement('p');
+      source.className = 'recipe-card__source';
+      const link = document.createElement('a');
+      link.href = recipe.sourceUrl;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = recipe.sourceName
+        ? `View on ${recipe.sourceName}`
+        : 'View full recipe';
+      source.appendChild(link);
+      card.appendChild(source);
+    }
+
+    li.appendChild(card);
+    ul.appendChild(li);
+  });
+
+  fragment.appendChild(ul);
+  listEl.innerHTML = '';
+  listEl.appendChild(fragment);
+}
+
+const SAMPLE_RECIPES = [
+  {
+    id: 'demo-roast-chicken',
+    title: 'Herbed Roast Chicken',
+    readyInMinutes: 75,
+    servings: 4,
+    spoonacularScore: 91,
+    healthScore: 45,
+    pricePerServing: 450,
+    aggregateLikes: 812,
+    cuisines: ['American'],
+    dishTypes: ['Main course'],
+    occasions: ['Sunday Dinner'],
+    summary: 'A comforting roast chicken with rosemary, garlic, and lemon.',
+    extendedIngredients: [
+      { original: '1 whole chicken (about 4 lbs)' },
+      { original: '2 tbsp olive oil' },
+      { original: '4 cloves garlic, minced' },
+      { original: '1 tbsp chopped fresh rosemary' },
+      { original: '1 lemon, halved' },
+      { original: '1 tsp kosher salt' },
+      { original: '1/2 tsp black pepper' }
+    ],
+    analyzedInstructions: [
+      {
+        steps: [
+          { step: 'Preheat oven to 425°F (220°C). Pat the chicken dry with paper towels.' },
+          { step: 'Rub the chicken with olive oil, garlic, rosemary, salt, and pepper.' },
+          { step: 'Stuff the cavity with lemon halves and roast for 65-75 minutes until juices run clear.' },
+          { step: 'Rest for 10 minutes before carving. Serve with pan juices.' }
+        ]
+      }
+    ],
+    winePairing: {
+      pairedWines: ['Chardonnay'],
+      pairingText: 'A buttery Chardonnay complements the roasted garlic and herbs.'
+    },
+    sourceName: 'Demo Kitchen',
+    sourceUrl: 'https://example.com/herbed-roast-chicken'
+  },
+  {
+    id: 'demo-lentil-soup',
+    title: 'Hearty Lentil Soup',
+    readyInMinutes: 45,
+    servings: 6,
+    spoonacularScore: 88,
+    healthScore: 82,
+    pricePerServing: 210,
+    aggregateLikes: 642,
+    cuisines: ['Mediterranean'],
+    dishTypes: ['Soup'],
+    diets: ['Vegetarian', 'Vegan', 'Gluten Free'],
+    summary: 'A cozy plant-based lentil soup packed with vegetables and warm spices.',
+    extendedIngredients: [
+      { original: '2 tbsp olive oil' },
+      { original: '1 yellow onion, diced' },
+      { original: '2 carrots, sliced' },
+      { original: '2 celery stalks, chopped' },
+      { original: '3 cloves garlic, minced' },
+      { original: '1 tsp ground cumin' },
+      { original: '1 tsp smoked paprika' },
+      { original: '1 cup dried green lentils, rinsed' },
+      { original: '1 (14 oz) can diced tomatoes' },
+      { original: '4 cups vegetable broth' },
+      { original: '2 cups chopped kale' }
+    ],
+    analyzedInstructions: [
+      {
+        steps: [
+          { step: 'Sauté onion, carrots, and celery in olive oil until softened.' },
+          { step: 'Add garlic, cumin, and paprika; cook until fragrant.' },
+          { step: 'Stir in lentils, tomatoes, and broth. Simmer 25 minutes until lentils are tender.' },
+          { step: 'Fold in kale and cook 5 minutes more. Season to taste.' }
+        ]
+      }
+    ],
+    winePairing: {
+      pairedWines: ['Pinot Noir'],
+      pairingText: 'A light Pinot Noir balances the earthiness of the lentils.'
+    },
+    vegetarian: true,
+    vegan: true,
+    glutenFree: true,
+    dairyFree: true,
+    veryHealthy: true,
+    sourceName: 'Demo Kitchen',
+    sourceUrl: 'https://example.com/hearty-lentil-soup'
+  },
+  {
+    id: 'demo-berry-parfait',
+    title: 'Summer Berry Parfait',
+    readyInMinutes: 15,
+    servings: 4,
+    spoonacularScore: 84,
+    healthScore: 55,
+    pricePerServing: 180,
+    aggregateLikes: 312,
+    cuisines: ['American'],
+    dishTypes: ['Dessert'],
+    occasions: ['Brunch'],
+    summary: 'Layers of vanilla yogurt, honey granola, and fresh berries for a quick dessert.',
+    extendedIngredients: [
+      { original: '2 cups vanilla Greek yogurt' },
+      { original: '1 cup mixed berries (strawberries, blueberries, raspberries)' },
+      { original: '1 cup honey granola' },
+      { original: '2 tbsp honey' },
+      { original: 'Fresh mint for garnish' }
+    ],
+    analyzedInstructions: [
+      {
+        steps: [
+          { step: 'Spoon a layer of yogurt into four glasses.' },
+          { step: 'Top with granola and a drizzle of honey.' },
+          { step: 'Add berries and repeat layers. Garnish with mint.' }
+        ]
+      }
+    ],
+    winePairing: {
+      pairedWines: ['Prosecco'],
+      pairingText: 'A chilled Prosecco keeps the parfait bright and celebratory.'
+    },
+    vegetarian: true,
+    sourceName: 'Demo Kitchen',
+    sourceUrl: 'https://example.com/summer-berry-parfait'
+  }
+]
+  .map(normalizeRecipe)
+  .filter(Boolean);
+
 export async function initRecipesPanel() {
   const listEl = document.getElementById('recipesList');
   if (!listEl) return;
@@ -123,55 +556,7 @@ export async function initRecipesPanel() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       const recipes = Array.isArray(data?.results)
-        ? data.results.map(r => {
-            const instructions = Array.isArray(r.analyzedInstructions)
-              ? r.analyzedInstructions
-                  .flatMap(instruction => instruction?.steps || [])
-                  .map(step => step?.step?.trim())
-                  .filter(Boolean)
-              : [];
-            const ingredients = Array.isArray(r.extendedIngredients)
-              ? r.extendedIngredients
-                  .map(ing => ing?.original || ing?.name || '')
-                  .map(text => stripHtml(text))
-                  .filter(Boolean)
-              : [];
-            const summary = stripHtml(r.summary);
-            const facts = buildFactEntries(r);
-            const tagGroups = buildTagGroups(r);
-            const badges = buildBadges(r);
-            const winePairing = {
-              wines: Array.isArray(r.winePairing?.pairedWines)
-                ? r.winePairing.pairedWines.filter(Boolean)
-                : [],
-              text: stripHtml(r.winePairing?.pairingText)
-            };
-            const storage = {
-              id: r.id ?? null,
-              title: r.title || 'Untitled',
-              sourceUrl: r.sourceUrl || ''
-            };
-            const storageKey = toUniqueKey(storage);
-            return {
-              storage,
-              storageKey,
-              title: r.title || 'Untitled',
-              image: r.image || '',
-              summary,
-              ingredients,
-              instructions,
-              facts,
-              tagGroups,
-              badges,
-              score:
-                typeof r.spoonacularScore === 'number'
-                  ? r.spoonacularScore
-                  : null,
-              sourceName: r.sourceName || '',
-              sourceUrl: r.sourceUrl || '',
-              winePairing
-            };
-          })
+        ? data.results.map(normalizeRecipe).filter(Boolean)
         : [];
       if (recipes.length === 0) {
         listEl.textContent = 'No recipes found.';
@@ -188,234 +573,25 @@ export async function initRecipesPanel() {
         listEl.innerHTML = '<p><em>No recipes to show. Try unhiding recipes or searching again.</em></p>';
         return;
       }
-      const ul = document.createElement('ul');
-      ul.className = 'recipe-card-list';
-      limited.forEach(recipe => {
-        const li = document.createElement('li');
-        li.className = 'recipe-card-item';
-
-        const card = document.createElement('article');
-        card.className = 'recipe-card';
-
-        const header = document.createElement('header');
-        header.className = 'recipe-card__header';
-
-        const title = document.createElement('h3');
-        title.className = 'recipe-card__title';
-        title.textContent = recipe.title;
-        header.appendChild(title);
-
-        const actions = document.createElement('div');
-        actions.className = 'recipe-card__actions';
-
-        const saveBtn = document.createElement('button');
-        saveBtn.className = 'recipe-card__action';
-        saveBtn.textContent = 'Save';
-        if (
-          readArray('recipesSaved').some(savedRecipe => {
-            const savedKey = toUniqueKey(savedRecipe);
-            return savedKey === recipe.storageKey;
-          })
-        ) {
-          saveBtn.textContent = 'Saved';
-          saveBtn.disabled = true;
-        }
-        saveBtn.addEventListener('click', () => {
-          const saved = readArray('recipesSaved');
-          if (
-            !saved.some(savedRecipe => {
-              const savedKey = toUniqueKey(savedRecipe);
-              return savedKey === recipe.storageKey;
-            })
-          ) {
-            saved.push(recipe.storage);
-            writeArray('recipesSaved', saved);
-          }
-          saveBtn.textContent = 'Saved';
-          saveBtn.disabled = true;
-        });
-        actions.appendChild(saveBtn);
-
-        const hideBtn = document.createElement('button');
-        hideBtn.className = 'recipe-card__action';
-        hideBtn.textContent = 'Hide';
-        hideBtn.addEventListener('click', () => {
-          const stored = readArray('recipesHidden').map(String);
-          if (!stored.includes(recipe.storageKey)) {
-            stored.push(recipe.storageKey);
-            writeArray('recipesHidden', stored);
-          }
-          li.remove();
-        });
-        actions.appendChild(hideBtn);
-
-        header.appendChild(actions);
-        card.appendChild(header);
-
-        if (recipe.image) {
-          const figure = document.createElement('figure');
-          figure.className = 'recipe-card__media';
-          const img = document.createElement('img');
-          img.className = 'recipe-card__image';
-          img.src = recipe.image;
-          img.alt = `${recipe.title} photo`;
-          figure.appendChild(img);
-          card.appendChild(figure);
-        }
-
-        if (recipe.summary) {
-          const summary = document.createElement('p');
-          summary.className = 'recipe-card__summary';
-          summary.textContent = recipe.summary;
-          card.appendChild(summary);
-        }
-
-        if (recipe.badges.length) {
-          const badgeWrap = document.createElement('div');
-          badgeWrap.className = 'recipe-card__badges';
-          recipe.badges.forEach(label => {
-            const badge = document.createElement('span');
-            badge.className = 'recipe-card__badge';
-            badge.textContent = label;
-            badgeWrap.appendChild(badge);
-          });
-          card.appendChild(badgeWrap);
-        }
-
-        if (recipe.facts.length) {
-          const facts = document.createElement('dl');
-          facts.className = 'recipe-card__facts';
-          recipe.facts.forEach(([label, value]) => {
-            const wrapper = document.createElement('div');
-            wrapper.className = 'recipe-card__fact';
-            const factLabel = document.createElement('dt');
-            factLabel.className = 'recipe-card__fact-label';
-            factLabel.textContent = label;
-            const factValue = document.createElement('dd');
-            factValue.className = 'recipe-card__fact-value';
-            factValue.textContent = value;
-            wrapper.appendChild(factLabel);
-            wrapper.appendChild(factValue);
-            facts.appendChild(wrapper);
-          });
-          card.appendChild(facts);
-        }
-
-        if (recipe.tagGroups.length) {
-          const tagSection = document.createElement('div');
-          tagSection.className = 'recipe-card__tags';
-          recipe.tagGroups.forEach(group => {
-            const groupEl = document.createElement('div');
-            groupEl.className = 'recipe-card__tag-group';
-            const groupLabel = document.createElement('span');
-            groupLabel.className = 'recipe-card__tag-label';
-            groupLabel.textContent = group.label;
-            groupEl.appendChild(groupLabel);
-            group.items.forEach(item => {
-              const chip = document.createElement('span');
-              chip.className = 'recipe-card__tag';
-              chip.textContent = item;
-              groupEl.appendChild(chip);
-            });
-            tagSection.appendChild(groupEl);
-          });
-          card.appendChild(tagSection);
-        }
-
-        if (recipe.ingredients.length) {
-          const section = document.createElement('section');
-          section.className = 'recipe-card__section';
-          const heading = document.createElement('h4');
-          heading.className = 'recipe-card__section-title';
-          heading.textContent = 'Ingredients';
-          section.appendChild(heading);
-          const list = document.createElement('ul');
-          list.className = 'recipe-card__ingredients';
-          recipe.ingredients.forEach(item => {
-            const ingItem = document.createElement('li');
-            ingItem.textContent = item;
-            list.appendChild(ingItem);
-          });
-          section.appendChild(list);
-          card.appendChild(section);
-        }
-
-        if (recipe.instructions.length) {
-          const section = document.createElement('section');
-          section.className = 'recipe-card__section';
-          const heading = document.createElement('h4');
-          heading.className = 'recipe-card__section-title';
-          heading.textContent = 'Instructions';
-          section.appendChild(heading);
-          const list = document.createElement('ol');
-          list.className = 'recipe-card__steps';
-          recipe.instructions.forEach(step => {
-            const stepItem = document.createElement('li');
-            stepItem.textContent = step;
-            list.appendChild(stepItem);
-          });
-          section.appendChild(list);
-          card.appendChild(section);
-        }
-
-        if (recipe.winePairing.wines.length || recipe.winePairing.text) {
-          const section = document.createElement('section');
-          section.className = 'recipe-card__section';
-          const heading = document.createElement('h4');
-          heading.className = 'recipe-card__section-title';
-          heading.textContent = 'Wine pairing';
-          section.appendChild(heading);
-          if (recipe.winePairing.wines.length) {
-            const wines = document.createElement('p');
-            wines.className = 'recipe-card__wine-list';
-            wines.textContent = recipe.winePairing.wines.join(', ');
-            section.appendChild(wines);
-          }
-          if (recipe.winePairing.text) {
-            const details = document.createElement('p');
-            details.className = 'recipe-card__wine-text';
-            details.textContent = recipe.winePairing.text;
-            section.appendChild(details);
-          }
-          card.appendChild(section);
-        }
-
-        if (recipe.sourceUrl) {
-          const source = document.createElement('p');
-          source.className = 'recipe-card__source';
-          const link = document.createElement('a');
-          link.href = recipe.sourceUrl;
-          link.target = '_blank';
-          link.rel = 'noopener noreferrer';
-          link.textContent = recipe.sourceName
-            ? `View on ${recipe.sourceName}`
-            : 'View full recipe';
-          source.appendChild(link);
-          card.appendChild(source);
-        }
-
-        li.appendChild(card);
-        ul.appendChild(li);
-      });
-      listEl.innerHTML = '';
-      listEl.appendChild(ul);
+      renderRecipeCards(listEl, limited, { onReload: loadRecipes });
       localStorage.setItem('recipesQuery', query);
     } catch (err) {
       console.error('Failed to load recipes', err);
-      const instructions = document.createElement('div');
-      instructions.className = 'recipes-error';
-      instructions.innerHTML = `
-        <p>We couldn't reach the recipes service.</p>
-        <p>To fix this locally:</p>
-        <ol>
-          <li>Create a <code>.env</code> file next to <code>backend/server.js</code> with your Spoonacular key, e.g. <code>SPOONACULAR_KEY=your_api_key_here</code>.</li>
-          <li>Restart the server with <code>npm start</code> so <code>/api/spoonacular</code> becomes available.</li>
-          <li>If you rely on a hosted proxy instead, assign its base URL to <code>window.apiBaseUrl</code> before calling <code>initRecipesPanel()</code>.</li>
-        </ol>
-        <p>After updating the configuration, try searching again.</p>
-      `;
-      listEl.innerHTML = '';
-      listEl.appendChild(instructions);
+      const hidden = readArray('recipesHidden').map(String);
+      const fallback = SAMPLE_RECIPES.filter(recipe => !hidden.includes(recipe.storageKey));
+      renderRecipeCards(listEl, fallback, {
+        onReload: loadRecipes,
+        noticeContent: `
+          <p><strong>Showing demo recipes.</strong> The live recipe service could not be reached (${err?.message || 'unknown error'}).</p>
+          <p>To restore live searches:</p>
+          <ol>
+            <li>Create a <code>.env</code> file next to <code>backend/server.js</code> with your Spoonacular key, e.g. <code>SPOONACULAR_KEY=your_api_key_here</code>.</li>
+            <li>Restart the server with <code>npm start</code> so <code>/api/spoonacular</code> becomes available.</li>
+            <li>If you rely on a hosted proxy instead, assign its base URL to <code>window.apiBaseUrl</code> before calling <code>initRecipesPanel()</code>.</li>
+          </ol>
+          <p>After updating the configuration, try searching again.</p>
+        `
+      });
     } finally {
       if (searchBtn) searchBtn.disabled = false;
     }

--- a/style.css
+++ b/style.css
@@ -2768,6 +2768,25 @@ h2 {
   font-size: 0.95rem;
 }
 
+.restaurants-demo-notice {
+  background: #eef6fb;
+  border: 1px solid rgba(23, 85, 118, 0.18);
+  color: #1a516b;
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.restaurants-demo-notice p {
+  margin: 0 0 0.5rem;
+}
+
+.restaurants-demo-notice p:last-child {
+  margin-bottom: 0;
+}
+
 .restaurants-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -3112,6 +3131,37 @@ h2 {
 
 .recipe-card__source a:hover {
   text-decoration: underline;
+}
+
+.recipes-demo-notice {
+  background: #fff7eb;
+  border: 1px solid rgba(168, 110, 8, 0.2);
+  color: #6f4704;
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+  line-height: 1.6;
+}
+
+.recipes-demo-notice p {
+  margin: 0 0 0.65rem;
+}
+
+.recipes-demo-notice p:last-child {
+  margin-bottom: 0;
+}
+
+.recipes-demo-notice ol {
+  margin: 0.35rem 0 0 1.25rem;
+  padding: 0;
+}
+
+.recipes-demo-notice li {
+  margin-bottom: 0.35rem;
+}
+
+.recipes-demo-notice li:last-child {
+  margin-bottom: 0;
 }
 
 @media (max-width: 600px) {

--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -186,4 +186,21 @@ describe('initRecipesPanel', () => {
     const container = document.getElementById('recipesApiKeyContainer');
     expect(container.style.display).toBe('none');
   });
+
+  it('shows demo recipes when the fetch fails', async () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error('Network down')));
+
+    await initRecipesPanel();
+    document.getElementById('recipesQuery').value = 'pasta';
+    document.getElementById('recipesSearchBtn').click();
+    await new Promise(r => setTimeout(r, 0));
+
+    const notice = document.querySelector('.recipes-demo-notice');
+    expect(notice.textContent).toContain('Network down');
+
+    const titles = Array.from(
+      document.querySelectorAll('#recipesList .recipe-card__title')
+    ).map(el => el.textContent);
+    expect(titles).toContain('Herbed Roast Chicken');
+  });
 });


### PR DESCRIPTION
## Summary
- normalize recipe data and reuse a renderer so demo cards can display consistently
- add curated sample recipes and restaurants that appear with guidance when live services are unavailable
- style the new notices and cover the fallbacks with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e31d2bf3c48327bff5a48867fc1548