### PR TITLE
Restore previous tab styling layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,18 +84,10 @@
             <h2>Live Music</h2>
             <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
           </div>
-          <div id="ticketmasterForm" style="margin-bottom:1rem;display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;">
+          <div id="ticketmasterForm" style="margin-bottom:1rem;display:flex;align-items:center;gap:.5rem;">
             <button type="button" id="spotifyTokenBtn" style="margin-right:.5rem;">Login to Spotify</button>
             <span id="spotifyStatus"></span>
             <input type="password" id="ticketmasterApiKey" placeholder="Ticketmaster API Key" style="margin-right:.5rem;">
-            <button
-              type="button"
-              id="discoverShowsBtn"
-              data-default-label="Discover Shows"
-              data-loading-label="Discovering…"
-            >
-              Discover Shows
-            </button>
           </div>
           <div id="showsTabs" class="movie-tabs">
             <button type="button" class="movie-tab shows-tab active" data-target="showsFeedSection">Discover</button>

--- a/js/buttonStyles.js
+++ b/js/buttonStyles.js
@@ -23,61 +23,22 @@ function isIconButton(btn) {
 }
 
 // Apply styling to a single button (unless it’s detected as an icon)
-function resetButtonStyles(btn) {
-  btn.style.backgroundColor = '';
-  btn.style.color = '';
-  btn.style.border = '';
-  btn.style.cursor = '';
-}
-
-function shouldSkipStyling(btn) {
-  if (!btn) return true;
-
-  // 0️⃣ Don’t restyle our list-selector tabs
-  if (btn.classList.contains('list-tab') || btn.closest('#listTabs')) {
-    return true;
-  }
-
-  // Skip main navigation & panel tabs so they retain their bespoke styles
-  const tabSelectors = [
-    '.tab-button',
-    '.movie-tab',
-    '.shows-tab',
-    '.comedy-tab',
-    '.calendar-mobile-tab'
-  ];
-  if (tabSelectors.some(selector => btn.matches(selector))) {
-    return true;
-  }
-  const tabContainers = [
-    '#tabsContainer',
-    '.movie-tabs',
-    '.shows-tabs',
-    '.comedy-tabs',
-    '.calendar-mobile-tabs'
-  ];
-  if (tabContainers.some(selector => btn.closest(selector))) {
-    return true;
-  }
-
-  // 1️⃣ Skip icon-only buttons or tag-filter buttons
-  if (isIconButton(btn)) return true;
-  if (btn.classList.contains('tag-filter-button')) return true;
-
-  return false;
-}
-
 function styleButton(btn) {
-  if (shouldSkipStyling(btn)) {
-    resetButtonStyles(btn);
+  // 0️⃣ Don’t restyle our list-selector tabs
+  if (btn.classList.contains('list-tab')
+      || btn.closest('#listTabs')) {
     return;
   }
 
+  // 1️⃣ Skip icon-only buttons or tag-filter buttons
+  if (isIconButton(btn)) return;
+  if (btn.classList.contains('tag-filter-button')) return;
+
   // 2️⃣ Style everything else
   btn.style.backgroundColor = randomDarkColor();
-  btn.style.color = '#fff';
-  btn.style.border = 'none';
-  btn.style.cursor = 'pointer';
+  btn.style.color           = '#fff';
+  btn.style.border          = 'none';
+  btn.style.cursor          = 'pointer';
 }
 
 

--- a/js/shows.js
+++ b/js/shows.js
@@ -741,26 +741,10 @@ export async function initShowsPanel() {
   const tokenBtn = document.getElementById('spotifyTokenBtn');
   const statusEl = document.getElementById('spotifyStatus');
   const apiKeyInput = document.getElementById('ticketmasterApiKey');
-  const discoverBtn = document.getElementById('discoverShowsBtn');
   const tabsContainer = document.getElementById('showsTabs');
   const tokenInput = document.getElementById('spotifyToken');
 
   spotifyTokenInputRef = tokenInput || null;
-
-  const defaultDiscoverLabel = discoverBtn?.dataset.defaultLabel || discoverBtn?.textContent?.trim() || 'Discover Shows';
-  const loadingDiscoverLabel = discoverBtn?.dataset.loadingLabel || 'Discovering…';
-
-  const setDiscoverButtonIdle = () => {
-    if (!discoverBtn) return;
-    discoverBtn.disabled = false;
-    discoverBtn.textContent = defaultDiscoverLabel;
-  };
-
-  const setDiscoverButtonLoading = () => {
-    if (!discoverBtn) return;
-    discoverBtn.disabled = true;
-    discoverBtn.textContent = loadingDiscoverLabel;
-  };
 
   if (tabsContainer) {
     const tabButtons = Array.from(tabsContainer.querySelectorAll('.shows-tab'));
@@ -1068,19 +1052,7 @@ export async function initShowsPanel() {
 
   tokenBtn?.addEventListener('click', startAuth);
 
-  if (discoverBtn) {
-    discoverBtn.addEventListener('click', async () => {
-      setDiscoverButtonLoading();
-      try {
-        await loadShows();
-      } finally {
-        setDiscoverButtonIdle();
-      }
-    });
-  }
-
   await loadShows();
-  setDiscoverButtonIdle();
 }
 
 window.initShowsPanel = initShowsPanel;

--- a/style.css
+++ b/style.css
@@ -180,43 +180,6 @@ body.mild-glow {
   height: 6px;
 }
 
-.navbar .tabs {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  padding: 8px 24px 0;
-  margin: 0;
-  background: linear-gradient(180deg, rgba(249, 246, 240, 0.9), rgba(249, 246, 240, 0.6));
-  border-bottom: 1px solid #d3ded5;
-  overflow-x: auto;
-}
-
-.navbar .tabs .tab-button {
-  flex: 0 0 auto;
-  margin: 0;
-  padding: 8px 16px;
-  background: #f4f7f4;
-  color: #314437;
-  border: 1px solid #c7d5ca;
-  border-bottom: 3px solid transparent;
-  border-radius: 10px 10px 0 0;
-  font-weight: 600;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.navbar .tabs .tab-button:hover:not(.active) {
-  background: #e7f0ea;
-  border-color: #a9c4b4;
-}
-
-.navbar .tabs .tab-button.active {
-  background: #ffffff;
-  color: #233025;
-  border-color: #7aa68c;
-  border-bottom-color: #ffffff;
-  box-shadow: 0 4px 10px rgba(122, 166, 140, 0.18);
-}
-
 .navbar-right button:hover {
   background-color: #f2f2f2;
 }


### PR DESCRIPTION
## Summary
- revert the live music panel markup to its earlier structure without the discover button changes
- restore the prior button styling helper so navigation and tab buttons keep their original appearance
- remove the additional navbar tab CSS so the page layout matches the previous design

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e320d5ada88327a008238597604173