### PR TITLE
Hide Spotify login button when token stored

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -541,7 +541,10 @@ export async function initShowsPanel() {
     const storedToken =
       (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
     if (storedToken) {
-      if (tokenBtn) tokenBtn.textContent = 'Login to Spotify';
+      if (tokenBtn) {
+        tokenBtn.textContent = 'Login to Spotify';
+        tokenBtn.style.display = 'none';
+      }
       if (statusEl) {
         statusEl.textContent = 'Signed in to Spotify';
         statusEl.classList.add('shows-spotify-status');
@@ -551,7 +554,10 @@ export async function initShowsPanel() {
         tokenInput.style.display = 'none';
       }
     } else {
-      if (tokenBtn) tokenBtn.textContent = 'Login to Spotify';
+      if (tokenBtn) {
+        tokenBtn.textContent = 'Login to Spotify';
+        tokenBtn.style.display = '';
+      }
       if (statusEl) {
         statusEl.textContent = '';
         statusEl.classList.remove('shows-spotify-status');


### PR DESCRIPTION
## Summary
- hide the Spotify token login button once a stored token is detected
- reset the Spotify status indicator and button visibility when no token is available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e32bc0e2d083278fe65a6dbb0fa702