### PR TITLE
Sort recipes by score before limiting

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -122,8 +122,14 @@ export async function initRecipesPanel() {
       );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      const recipes = Array.isArray(data?.results)
-        ? data.results.map(r => {
+      const sortedResults = Array.isArray(data?.results)
+        ? [...data.results].sort((a, b) => {
+            const scoreA = typeof a?.spoonacularScore === 'number' ? a.spoonacularScore : 0;
+            const scoreB = typeof b?.spoonacularScore === 'number' ? b.spoonacularScore : 0;
+            return scoreB - scoreA;
+          })
+        : [];
+      const recipes = sortedResults.map(r => {
             const instructions = Array.isArray(r.analyzedInstructions)
               ? r.analyzedInstructions
                   .flatMap(instruction => instruction?.steps || [])
@@ -167,8 +173,7 @@ export async function initRecipesPanel() {
               sourceUrl: r.sourceUrl || '',
               winePairing
             };
-          })
-        : [];
+          });
       if (recipes.length === 0) {
         listEl.textContent = 'No recipes found.';
         return;

--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -118,6 +118,32 @@ describe('initRecipesPanel', () => {
     expect(items.length).toBe(10);
   });
 
+  it('orders recipes by spoonacular score descending', async () => {
+    const mockResponse = {
+      results: [
+        { title: 'Middle', spoonacularScore: 25 },
+        { title: 'Top', spoonacularScore: 90 },
+        { title: 'No Score' }
+      ]
+    };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      })
+    );
+
+    await initRecipesPanel();
+    document.getElementById('recipesQuery').value = 'scores';
+    document.getElementById('recipesSearchBtn').click();
+    await new Promise(r => setTimeout(r, 0));
+
+    const titles = Array.from(
+      document.querySelectorAll('#recipesList .recipe-card__title')
+    ).map(el => el.textContent);
+    expect(titles.slice(0, 3)).toEqual(['Top', 'Middle', 'No Score']);
+  });
+
   it('allows hiding a recipe persistently', async () => {
     const store = {};
     global.localStorage = {


### PR DESCRIPTION
## Summary
- sort Spoonacular search results by `spoonacularScore` (defaulting to 0) before transforming them for display so higher scoring recipes survive the 10 item cap
- add a unit test to confirm the rendered list respects the descending score order

## Testing
- npx vitest run tests/recipes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3ed21b5088327b688231abe105fdb