### PR TITLE
Fix movie priority fallback filtering

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -613,7 +613,7 @@ function selectPriorityCandidates(movies) {
     if (filtered.length >= MIN_PRIORITY_RESULTS) {
       return filtered;
     }
-    if (filtered.length > bestFallback.length) {
+    if (filtered.length && bestFallback.length === 0) {
       bestFallback = filtered;
     }
   }


### PR DESCRIPTION
## Summary
- keep the strictest qualifying movie set when falling back from priority thresholds so low-quality entries stay filtered out

## Testing
- npm test -- --run tests/movies.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3edc426dc8327bb0f70788a426161