### PR TITLE
Add Spotify fallback suggestions for empty live shows panel

### DIFF
--- a/style.css
+++ b/style.css
@@ -802,6 +802,71 @@ button:hover {
   font-weight: 600;
 }
 
+.shows-suggestions {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shows-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d5e7df;
+  border-radius: 14px;
+  background: #f7fbf9;
+}
+
+.shows-suggestion__image {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  object-fit: cover;
+  flex-shrink: 0;
+  box-shadow: 0 4px 10px rgba(31, 74, 64, 0.12);
+}
+
+.shows-suggestion__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.shows-suggestion__name {
+  margin: 0;
+  font-weight: 700;
+  color: #1f4a40;
+}
+
+.shows-suggestion__artists {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #3d5f58;
+}
+
+.shows-suggestion__link {
+  margin-top: 0.3rem;
+  align-self: flex-start;
+  color: #2f7f70;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.shows-suggestion__link:hover {
+  text-decoration: underline;
+}
+
+.shows-suggestions__title {
+  margin: 1.5rem 0 0.25rem;
+  font-size: 1rem;
+  color: #1f4a40;
+  font-weight: 700;
+  text-align: left;
+}
+
 #spotifyStatus,
 .shows-spotify-status {
   font-size: 0.85rem;

--- a/tests/showsSpotify.test.js
+++ b/tests/showsSpotify.test.js
@@ -329,4 +329,63 @@ describe('initShowsPanel', () => {
 
     expect(fetch.mock.calls[2][0]).toContain('apiKey=manualKey');
   });
+
+  it('shows Spotify suggestions when no live shows are available', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ clientId: 'cid', hasTicketmasterKey: true }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{ name: 'Top Artist', id: 'artist1' }]
+        })
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ _embedded: { events: [] } }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tracks: [
+            {
+              id: 'track1',
+              name: 'Song One',
+              artists: [{ name: 'Artist A' }],
+              external_urls: { spotify: 'https://spotify.com/track1' },
+              album: { images: [{ url: 'https://img/1.jpg', width: 300 }] }
+            },
+            {
+              id: 'track2',
+              name: 'Song Two',
+              artists: [{ name: 'Artist B' }],
+              external_urls: { spotify: 'https://spotify.com/track2' },
+              album: { images: [{ url: 'https://img/2.jpg', width: 300 }] }
+            },
+            {
+              id: 'track3',
+              name: 'Song Three',
+              artists: [{ name: 'Artist C' }],
+              external_urls: { spotify: 'https://spotify.com/track3' },
+              album: { images: [{ url: 'https://img/3.jpg', width: 300 }] }
+            },
+            {
+              id: 'track4',
+              name: 'Song Four',
+              artists: [{ name: 'Artist D' }],
+              external_urls: { spotify: 'https://spotify.com/track4' },
+              album: { images: [{ url: 'https://img/4.jpg', width: 300 }] }
+            }
+          ]
+        })
+      });
+
+    localStorage.setItem('spotifyToken', 'token');
+    await initShowsPanel();
+
+    await flush();
+    await flush();
+
+    expect(fetch).toHaveBeenCalledTimes(4);
+    const suggestions = document.querySelectorAll('.shows-suggestion');
+    expect(suggestions.length).toBe(4);
+    expect(document.querySelector('.shows-suggestions__title')?.textContent).toContain('Spotify suggestions');
+    expect(document.querySelector('.shows-empty')?.textContent).toContain('No nearby shows');
+  });
 });


### PR DESCRIPTION
## Summary
- add a Spotify recommendations fetch when no Ticketmaster events are found so the live shows panel still suggests content
- render the suggested tracks with images, artist names, and Spotify links plus supporting styles
- cover the fallback flow with a new shows panel unit test

## Testing
- `npm test -- showsSpotify`


------
https://chatgpt.com/codex/tasks/task_e_68e3ee0508508327b4741d5d81fa10e2