### PR TITLE
feat: collapse long recipe summaries

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -262,10 +262,33 @@ export async function initRecipesPanel() {
         }
 
         if (recipe.summary) {
+          const summaryWrap = document.createElement('div');
+          summaryWrap.className = 'recipe-card__summary-wrap';
+
           const summary = document.createElement('p');
           summary.className = 'recipe-card__summary';
           summary.textContent = recipe.summary;
-          card.appendChild(summary);
+          summaryWrap.appendChild(summary);
+
+          if (recipe.summary.length > 240) {
+            const toggle = document.createElement('button');
+            toggle.type = 'button';
+            toggle.className = 'recipe-card__summary-toggle';
+            toggle.textContent = 'Show more';
+            toggle.setAttribute('aria-expanded', 'false');
+
+            toggle.addEventListener('click', () => {
+              const expanded = toggle.getAttribute('aria-expanded') === 'true';
+              const nextExpanded = !expanded;
+              toggle.setAttribute('aria-expanded', String(nextExpanded));
+              summary.classList.toggle('recipe-card__summary--expanded', nextExpanded);
+              toggle.textContent = nextExpanded ? 'Show less' : 'Show more';
+            });
+
+            summaryWrap.appendChild(toggle);
+          }
+
+          card.appendChild(summaryWrap);
         }
 
         if (recipe.badges.length) {

--- a/style.css
+++ b/style.css
@@ -2859,10 +2859,40 @@ h2 {
   display: block;
 }
 
+.recipe-card__summary-wrap {
+  display: grid;
+  gap: 0.5rem;
+}
+
 .recipe-card__summary {
   margin: 0;
   color: #544c3a;
   line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.recipe-card__summary--expanded {
+  display: block;
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+
+.recipe-card__summary-toggle {
+  justify-self: start;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #256029;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.recipe-card__summary-toggle:hover,
+.recipe-card__summary-toggle:focus-visible {
+  text-decoration: underline;
 }
 
 .recipe-card__badges {

--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -98,6 +98,36 @@ describe('initRecipesPanel', () => {
     expect(tagChip.textContent).toBe('American');
   });
 
+  it('allows expanding long summaries', async () => {
+    const mockResponse = {
+      results: [
+        {
+          title: 'Verbose',
+          summary: 'Long description '.repeat(30)
+        }
+      ]
+    };
+    global.fetch = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(mockResponse)
+    }));
+
+    await initRecipesPanel();
+    document.getElementById('recipesQuery').value = 'verbose';
+    document.getElementById('recipesSearchBtn').click();
+    await new Promise(r => setTimeout(r, 0));
+
+    const toggle = document.querySelector('.recipe-card__summary-toggle');
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    toggle.click();
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    const summary = document.querySelector('.recipe-card__summary');
+    expect(summary.classList.contains('recipe-card__summary--expanded')).toBe(true);
+  });
+
   it('limits displayed recipes to 10', async () => {
     const mockResponse = {
       results: Array.from({ length: 12 }, (_, i) => ({


### PR DESCRIPTION
## Summary
- collapse recipe summaries to five lines by default and add an expand/collapse toggle
- add styles for the summary clamp and toggle interactions
- cover the new toggle behavior with a unit test

## Testing
- npx vitest run tests/recipes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3ee9dc5e08327aa898e78e3381d4f