### PR TITLE
Ensure restaurants map maintains square aspect ratio

### DIFF
--- a/style.css
+++ b/style.css
@@ -2596,6 +2596,8 @@ h2 {
 }
 
 .restaurants-map {
+  width: 100%;
+  aspect-ratio: 1 / 1;
   min-height: 260px;
   border-radius: 18px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- ensure the restaurants map container expands to the full column width while keeping a square aspect ratio
- retain the existing minimum height so the map never collapses on narrow screens

## Testing
- vitest run


------
https://chatgpt.com/codex/tasks/task_e_68e3ed4041708327a1705f4e77f5f14b