### PR TITLE
Ensure movie feed loads minimum results

### DIFF
--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -118,7 +118,7 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [{ id: 28, name: 'Action' }] };
 
-    configureFetchResponses([page, empty, empty, credits, genres]);
+    configureFetchResponses([page, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -182,7 +182,7 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, credits, genres]);
+    configureFetchResponses([page, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -231,7 +231,7 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, creditsHigh, creditsLow, genres]);
+    configureFetchResponses([page, empty, creditsHigh, creditsLow, genres]);
 
     await initMoviesPanel();
 
@@ -266,7 +266,7 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, credits, genres]);
+    configureFetchResponses([page, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -321,7 +321,7 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, credits, genres]);
+    configureFetchResponses([page, empty, credits, genres]);
 
     await initMoviesPanel();
     const calledUrls = fetch.mock.calls.map(args => args[0]);
@@ -359,7 +359,7 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, credits, genres]);
+    configureFetchResponses([page, empty, credits, genres]);
 
     await initMoviesPanel();
 
@@ -407,7 +407,7 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [] };
 
-    configureFetchResponses([page, empty, empty, credits, genres]);
+    configureFetchResponses([page, empty, credits, genres]);
 
     await initMoviesPanel();
 


### PR DESCRIPTION
## Summary
- request additional TMDB discover pages until the prioritized feed has at least ten unsuppressed movies
- share feed filtering logic so load-time heuristics mirror rendering behavior
- update movie panel tests to match the new pagination sequence

## Testing
- npx vitest run tests/movies.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e32b45ecec8327be3525bbe6ce5c81