### PR TITLE
Document TMDB configuration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ Spoonacular proxy. To fix this locally:
 3. If you are using a hosted proxy instead of the local server, assign its base URL to `window.apiBaseUrl` before the dashboard initializes.
 
 After applying one of the setups above, reload the page and try the search again.
+
+## Movies panel setup
+
+If the Movies tab shows a TMDB API key prompt, configure the Cloud Functions
+environment (or local environment variables) with a valid key so the TMDB proxy
+remains enabled. Run the following command, replacing `YOUR_TMDB_KEY` with your
+actual key:
+
+```bash
+firebase functions:config:set tmdb.key="YOUR_TMDB_KEY"
+```
+
+Deploy the updated configuration or restart your local emulator so the change
+takes effect, and reload the dashboard afterwards.


### PR DESCRIPTION
## Summary
- document how to configure the TMDB API key so the Movies proxy remains enabled

## Testing
- vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e3f0717bf08327999c3649ec49f205