### PR TITLE
Add saved and hidden controls to restaurants panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,46 @@
           role="img"
           aria-label="Map showing nearby restaurant locations"
         ></div>
-        <div id="restaurantsResults" class="restaurants-list decision-container" aria-live="polite"></div>
+        <div id="restaurantsResults" class="restaurants-list decision-container" aria-live="polite">
+          <div class="restaurants-tabs" role="tablist" aria-label="Restaurant lists">
+            <button
+              type="button"
+              id="restaurantsNearbyTab"
+              class="restaurants-tab is-active"
+              data-view="nearby"
+              role="tab"
+              aria-selected="true"
+              aria-controls="restaurantsNearby"
+            >
+              Nearby
+            </button>
+            <button
+              type="button"
+              id="restaurantsSavedTab"
+              class="restaurants-tab"
+              data-view="saved"
+              role="tab"
+              aria-selected="false"
+              aria-controls="restaurantsSaved"
+            >
+              Saved
+            </button>
+          </div>
+          <div
+            id="restaurantsNearby"
+            class="restaurants-section"
+            role="tabpanel"
+            aria-labelledby="restaurantsNearbyTab"
+          ></div>
+          <div
+            id="restaurantsSaved"
+            class="restaurants-section"
+            role="tabpanel"
+            aria-labelledby="restaurantsSavedTab"
+            hidden
+          ></div>
+          <div id="restaurantsHiddenSection" class="restaurants-hidden" aria-live="polite"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -2820,12 +2820,142 @@ h2 {
   font-size: 0.85rem;
   font-weight: 600;
   transition: background 0.2s ease, transform 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: none;
+  cursor: pointer;
+}
+
+.restaurant-action:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
 }
 
 .restaurant-action:hover,
 .restaurant-action:focus-visible {
   background: #2e5346;
   transform: translateY(-1px);
+}
+
+.restaurant-action.is-active {
+  background: #2e5346;
+}
+
+.restaurant-action--secondary {
+  background: #ffffff;
+  color: #1f3631;
+  border: 1px solid rgba(33, 65, 54, 0.2);
+}
+
+.restaurant-action--secondary:hover,
+.restaurant-action--secondary:focus-visible {
+  background: rgba(33, 65, 54, 0.12);
+  color: #1f3631;
+  transform: none;
+}
+
+.restaurant-action--danger {
+  background: #7a2e26;
+}
+
+.restaurant-action--danger:hover,
+.restaurant-action--danger:focus-visible {
+  background: #9d3d32;
+}
+
+.restaurants-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.restaurants-tab {
+  border: 1px solid rgba(33, 65, 54, 0.2);
+  background: #ffffff;
+  color: #1f3631;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.restaurants-tab.is-active {
+  background: #1f3631;
+  color: #ffffff;
+  border-color: #1f3631;
+}
+
+.restaurants-tab:focus-visible {
+  outline: 2px solid rgba(31, 54, 49, 0.4);
+  outline-offset: 2px;
+}
+
+.restaurants-section {
+  display: block;
+}
+
+.restaurants-section[hidden] {
+  display: none;
+}
+
+.restaurants-hidden {
+  margin-top: 2rem;
+  border-top: 1px solid rgba(33, 65, 54, 0.12);
+  padding-top: 1.5rem;
+  display: none;
+  gap: 0.75rem;
+  flex-direction: column;
+}
+
+.restaurants-hidden.is-visible {
+  display: flex;
+}
+
+.restaurants-hidden h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #1f3631;
+}
+
+.restaurants-hidden-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.restaurants-hidden-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(33, 65, 54, 0.08);
+}
+
+.restaurants-hidden-name {
+  font-weight: 600;
+  color: #1f3631;
+}
+
+.restaurants-hidden button {
+  background: transparent;
+  border: 1px solid rgba(31, 54, 49, 0.35);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  font-weight: 600;
+  color: #1f3631;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.restaurants-hidden button:hover,
+.restaurants-hidden button:focus-visible {
+  background: rgba(31, 54, 49, 0.12);
+  border-color: #1f3631;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- add Save and Hide Forever actions to restaurant cards with persistent storage
- introduce nearby/saved subtabs and a hidden section to surface saved and hidden restaurants
- update restaurant panel logic, styling, and tests to cover the new behaviors

## Testing
- npm test -- restaurants

------
https://chatgpt.com/codex/tasks/task_e_68e3f21edf008327ab616fc929213170