### PR TITLE
Ensure Discover button works without Spotify client ID

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -631,17 +631,16 @@ export async function initShowsPanel() {
     console.error('Failed to fetch Spotify client ID', err);
   }
   if (!spotifyClientId) {
-    if (listEl) {
+    if (listEl && !listEl.textContent) {
       listEl.textContent = 'Spotify client ID not configured.';
     }
-    if (interestedListEl) {
+    if (interestedListEl && !interestedListEl.childElementCount) {
       interestedListEl.innerHTML = '';
       const warning = document.createElement('p');
       warning.className = 'shows-empty';
       warning.textContent = 'Spotify client ID not configured.';
       interestedListEl.appendChild(warning);
     }
-    return;
   }
 
   if (serverHasTicketmasterKey && apiKeyInput) {


### PR DESCRIPTION
## Summary
- allow the shows panel to continue initializing when the Spotify client ID is missing so the Discover button remains active
- keep the warning messages but ensure the discover workflow can run with manually supplied tokens
- cover the regression with a dedicated test and DOM fixture updates for the shows panel

## Testing
- npm test -- showsSpotify

------
https://chatgpt.com/codex/tasks/task_e_68e3f517776083279193474c99a3334e