### PR TITLE
Display genres for saved and watched movies

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -271,6 +271,19 @@ function appendMeta(list, label, value) {
   list.appendChild(item);
 }
 
+function getGenreNames(movie) {
+  if (!movie) return [];
+  const ids = Array.isArray(movie.genre_ids) ? movie.genre_ids : [];
+  return ids.map(id => genreMap[id]).filter(Boolean);
+}
+
+function appendGenresMeta(list, movie) {
+  const genres = getGenreNames(movie);
+  if (genres.length) {
+    appendMeta(list, 'Genres', genres.join(', '));
+  }
+}
+
 function appendPeopleMeta(list, label, names) {
   const values = getNameList(names);
   if (!values.length) return;
@@ -444,12 +457,7 @@ function renderFeed() {
     const metaList = document.createElement('ul');
     metaList.className = 'movie-meta';
 
-    const genres = (movie.genre_ids || [])
-      .map(id => genreMap[id])
-      .filter(Boolean);
-    if (genres.length) {
-      appendMeta(metaList, 'Genres', genres.join(', '));
-    }
+    appendGenresMeta(metaList, movie);
     appendMeta(metaList, 'Average Score', movie.vote_average ?? 'N/A');
     appendMeta(metaList, 'Votes', movie.vote_count ?? 'N/A');
     appendMeta(metaList, 'Release Date', movie.release_date || 'Unknown');
@@ -543,6 +551,7 @@ function renderInterestedList() {
 
     const metaList = document.createElement('ul');
     metaList.className = 'movie-meta';
+    appendGenresMeta(metaList, movie);
     appendPeopleMeta(metaList, 'Director', movie.directors);
     appendPeopleMeta(metaList, 'Cast', movie.topCast);
     if (metaList.childNodes.length) {
@@ -604,6 +613,7 @@ function renderWatchedList() {
 
     const metaList = document.createElement('ul');
     metaList.className = 'movie-meta';
+    appendGenresMeta(metaList, movie);
     appendPeopleMeta(metaList, 'Director', movie.directors);
     appendPeopleMeta(metaList, 'Cast', movie.topCast);
     if (metaList.childNodes.length) {

--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -254,7 +254,7 @@ describe('initMoviesPanel', () => {
           vote_average: 8.2,
           vote_count: 84,
           overview: 'Must-watch film.',
-          genre_ids: [],
+          genre_ids: [18],
           poster_path: '/future.jpg'
         }
       ]
@@ -264,7 +264,7 @@ describe('initMoviesPanel', () => {
       cast: [{ name: 'Breakout Star' }],
       crew: [{ job: 'Director', name: 'Indie Director' }]
     };
-    const genres = { genres: [] };
+    const genres = { genres: [{ id: 18, name: 'Drama' }] };
 
     configureFetchResponses([page, empty, credits, genres]);
 
@@ -293,6 +293,7 @@ describe('initMoviesPanel', () => {
     const stored = JSON.parse(global.localStorage.getItem('moviePreferences'));
     expect(stored['2'].interest).toBe(5);
     const meta = document.querySelector('#savedMoviesList .movie-meta')?.textContent || '';
+    expect(meta).toContain('Genres: Drama');
     expect(meta).toContain('Director: Indie Director');
   });
 
@@ -348,7 +349,7 @@ describe('initMoviesPanel', () => {
           vote_average: 9.1,
           vote_count: 900,
           overview: 'A timeless classic.',
-          genre_ids: []
+          genre_ids: [12]
         }
       ]
     };
@@ -357,7 +358,7 @@ describe('initMoviesPanel', () => {
       cast: [{ name: 'Iconic Star' }],
       crew: [{ job: 'Director', name: 'Famed Director' }]
     };
-    const genres = { genres: [] };
+    const genres = { genres: [{ id: 12, name: 'Adventure' }] };
 
     configureFetchResponses([page, empty, credits, genres]);
 
@@ -370,7 +371,9 @@ describe('initMoviesPanel', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(document.querySelector('#watchedMoviesList').textContent).toContain('Classic Film');
-
+    const watchedMeta = document.querySelector('#watchedMoviesList .movie-meta')?.textContent || '';
+    expect(watchedMeta).toContain('Genres: Adventure');
+    
     const removeBtn = document.querySelector('#watchedMoviesList button');
     removeBtn?.click();
     await new Promise(resolve => setTimeout(resolve, 0));


### PR DESCRIPTION
## Summary
- add reusable helpers to translate TMDB genre IDs into labels when rendering movie metadata
- show the translated genre list in the interested and watched movie panels alongside other details
- extend movie panel tests to cover the newly displayed genres in saved lists

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3f2f66cbc832795de41cdddc0d099