### PR TITLE
Fix Ticketmaster discover URL builder

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -823,16 +823,20 @@ export async function initShowsPanel() {
       }
       const eventsMap = new Map();
       let eventCounter = 0;
+      const apiBase =
+        API_BASE_URL && API_BASE_URL !== 'null'
+          ? API_BASE_URL.replace(/\/$/, '')
+          : '';
       for (const artist of artists) {
-        const tmUrl = new URL(`${API_BASE_URL}/api/ticketmaster`);
-        tmUrl.searchParams.set('keyword', artist.name);
+        const params = new URLSearchParams({ keyword: artist.name });
         if (requiresManualApiKey) {
-          tmUrl.searchParams.set('apiKey', manualApiKey);
+          params.set('apiKey', manualApiKey);
         }
+        const tmUrl = `${apiBase}/api/ticketmaster?${params.toString()}`;
         const cacheScope = requiresManualApiKey ? 'manual' : 'server';
         let data = getCachedTicketmasterResponse(artist.name, cacheScope);
         if (!data) {
-          const res = await fetch(tmUrl.toString());
+          const res = await fetch(tmUrl);
           if (!res.ok) {
             if (res.status === 429) {
               console.warn('Ticketmaster rate limit reached for', artist.name);


### PR DESCRIPTION
## Summary
- avoid constructing Ticketmaster discovery requests with `new URL` so the Live Music Discover button works even when no explicit API base URL is configured
- reuse URLSearchParams to append keyword and optional manual API key while keeping cache behavior intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3f95dece08327ae8a7e4a8e1440a3