### PR TITLE
Add API Ninjas fallback for recipe searches

### DIFF
--- a/README copy.md
+++ b/README copy.md
@@ -43,6 +43,8 @@ npm install
 npm test
 ```
 
-### Spoonacular proxy
+### Recipes API
 
-The backend exposes a `/api/spoonacular` route that forwards recipe searches to the Spoonacular API without revealing your key. Define a `SPOONACULAR_KEY` environment variable before running the server when deploying (e.g., on Render).
+The app first tries to query the hosted Spoonacular proxy at `/api/spoonacular` (or `/spoonacularProxy` when using the Cloud Functions deployment). If the proxy cannot be reached, you can supply an [API Ninjas Recipe API](https://api-ninjas.com/api/recipe) key in the Recipes tab and the app will call their endpoint directly. The key is stored only in your browser's local storage so you do not need to re-enter it on every visit.
+
+To run the proxy locally, create a `.env` file with `SPOONACULAR_KEY=your_api_key_here` and restart the server with `npm start`.


### PR DESCRIPTION
## Summary
- enable the recipes panel to store a user-supplied API Ninjas key and fall back to the external API when the proxy is unavailable
- normalize recipe parsing so instructions and ingredients render correctly for both Spoonacular and API Ninjas responses, and update the on-page guidance
- refresh the documentation and tests to cover the new workflow

## Testing
- npm test -- tests/recipes.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e43b2ec9bc83278b44fc49ea3b6143