### PR TITLE
Add rating sorting controls to watched movies

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,14 @@
             <div id="savedMoviesList" class="decision-container"></div>
           </div>
           <div id="watchedMoviesSection" style="display:none;">
+            <div id="watchedMoviesControls" class="movie-controls">
+              <label for="watchedMoviesSort">Sort by:</label>
+              <select id="watchedMoviesSort">
+                <option value="recent">Recently Updated</option>
+                <option value="ratingDesc">Rating: High to Low</option>
+                <option value="ratingAsc">Rating: Low to High</option>
+              </select>
+            </div>
             <div id="watchedMoviesList" class="decision-container"></div>
           </div>
           <footer id="tmdbNotice" class="tmdb-notice">

--- a/js/movies.js
+++ b/js/movies.js
@@ -28,7 +28,8 @@ const domRefs = {
   tabs: null,
   streamSection: null,
   interestedSection: null,
-  watchedSection: null
+  watchedSection: null,
+  watchedSort: null
 };
 
 let currentMovies = [];
@@ -38,6 +39,7 @@ let activeApiKey = '';
 let prefsLoadedFor = null;
 let loadingPrefsPromise = null;
 let activeUserId = null;
+let watchedSortMode = 'recent';
 const handlers = {
   handleKeydown: null,
   handleChange: null
@@ -305,6 +307,33 @@ function appendPeopleMeta(list, label, names) {
   const values = getNameList(names);
   if (!values.length) return;
   appendMeta(list, label, values.join(', '));
+}
+
+function getVoteAverageValue(movie) {
+  if (!movie) return null;
+  const value = Number(movie.vote_average);
+  return Number.isFinite(value) ? value : null;
+}
+
+function getVoteCountValue(movie) {
+  if (!movie) return null;
+  const value = Number(movie.vote_count);
+  return Number.isFinite(value) ? value : null;
+}
+
+function createRatingElement(movie) {
+  const rating = getVoteAverageValue(movie);
+  const votes = getVoteCountValue(movie);
+  if (rating == null && votes == null) return null;
+  const ratingEl = document.createElement('p');
+  ratingEl.className = 'movie-rating';
+  if (rating == null) {
+    ratingEl.textContent = 'Rating not available';
+  } else {
+    const votesText = votes == null ? '' : ` (${votes} votes)`;
+    ratingEl.textContent = `Rating: ${rating.toFixed(1)} / 10${votesText}`;
+  }
+  return ratingEl;
 }
 
 function applyCreditsToMovie(movie, credits) {
@@ -594,17 +623,63 @@ function renderWatchedList() {
   const listEl = domRefs.watchedList;
   if (!listEl) return;
 
-  const entries = Object.values(currentPrefs)
-    .filter(pref => pref.status === 'watched' && pref.movie)
-    .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+  const entries = Object.values(currentPrefs).filter(
+    pref => pref.status === 'watched' && pref.movie
+  );
 
-  if (!entries.length) {
+  const sorted = entries.slice();
+
+  const byUpdatedAt = (a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
+  const byRatingDesc = (a, b) => {
+    const aRating = getVoteAverageValue(a.movie);
+    const bRating = getVoteAverageValue(b.movie);
+    if (aRating == null && bRating == null) return byUpdatedAt(a, b);
+    if (aRating == null) return 1;
+    if (bRating == null) return -1;
+    if (bRating !== aRating) return bRating - aRating;
+    const aVotes = getVoteCountValue(a.movie);
+    const bVotes = getVoteCountValue(b.movie);
+    if (aVotes == null && bVotes == null) return byUpdatedAt(a, b);
+    if (aVotes == null) return 1;
+    if (bVotes == null) return -1;
+    if (bVotes !== aVotes) return bVotes - aVotes;
+    return byUpdatedAt(a, b);
+  };
+  const byRatingAsc = (a, b) => {
+    const aRating = getVoteAverageValue(a.movie);
+    const bRating = getVoteAverageValue(b.movie);
+    if (aRating == null && bRating == null) return byUpdatedAt(a, b);
+    if (aRating == null) return 1;
+    if (bRating == null) return -1;
+    if (aRating !== bRating) return aRating - bRating;
+    const aVotes = getVoteCountValue(a.movie);
+    const bVotes = getVoteCountValue(b.movie);
+    if (aVotes == null && bVotes == null) return byUpdatedAt(a, b);
+    if (aVotes == null) return 1;
+    if (bVotes == null) return -1;
+    if (aVotes !== bVotes) return aVotes - bVotes;
+    return byUpdatedAt(a, b);
+  };
+
+  if (watchedSortMode === 'ratingDesc') {
+    sorted.sort(byRatingDesc);
+  } else if (watchedSortMode === 'ratingAsc') {
+    sorted.sort(byRatingAsc);
+  } else {
+    sorted.sort(byUpdatedAt);
+  }
+
+  if (domRefs.watchedSort) {
+    domRefs.watchedSort.value = watchedSortMode;
+  }
+
+  if (!sorted.length) {
     listEl.innerHTML = '<em>No watched movies yet.</em>';
     return;
   }
 
   const ul = document.createElement('ul');
-  entries.forEach(pref => {
+  sorted.forEach(pref => {
     const movie = pref.movie;
     const li = document.createElement('li');
     li.className = 'movie-card';
@@ -624,6 +699,11 @@ function renderWatchedList() {
     titleEl.textContent = `${movie.title || 'Untitled'} (${year})`;
     info.appendChild(titleEl);
 
+    const ratingEl = createRatingElement(movie);
+    if (ratingEl) {
+      info.appendChild(ratingEl);
+    }
+
     if (movie.overview) {
       const overview = document.createElement('p');
       overview.textContent = movie.overview;
@@ -632,6 +712,9 @@ function renderWatchedList() {
 
     const metaList = document.createElement('ul');
     metaList.className = 'movie-meta';
+    appendMeta(metaList, 'Average Score', movie.vote_average ?? 'N/A');
+    appendMeta(metaList, 'Votes', movie.vote_count ?? 'N/A');
+    appendMeta(metaList, 'Release Date', movie.release_date || 'Unknown');
     appendGenresMeta(metaList, movie);
     appendPeopleMeta(metaList, 'Director', movie.directors);
     appendPeopleMeta(metaList, 'Cast', movie.topCast);
@@ -904,6 +987,7 @@ export async function initMoviesPanel() {
   domRefs.streamSection = document.getElementById('movieStreamSection');
   domRefs.interestedSection = document.getElementById('savedMoviesSection');
   domRefs.watchedSection = document.getElementById('watchedMoviesSection');
+  domRefs.watchedSort = document.getElementById('watchedMoviesSort');
 
   currentPrefs = await loadPreferences();
 
@@ -971,6 +1055,23 @@ export async function initMoviesPanel() {
       btn._movieTabHandler = handler;
       btn.addEventListener('click', handler);
     });
+  }
+
+  if (domRefs.watchedSort) {
+    if (domRefs.watchedSort._moviesSortHandler) {
+      domRefs.watchedSort.removeEventListener(
+        'change',
+        domRefs.watchedSort._moviesSortHandler
+      );
+    }
+    const handler = () => {
+      const value = domRefs.watchedSort?.value || 'recent';
+      watchedSortMode = value;
+      renderWatchedList();
+    };
+    domRefs.watchedSort._moviesSortHandler = handler;
+    domRefs.watchedSort.addEventListener('change', handler);
+    domRefs.watchedSort.value = watchedSortMode;
   }
 
   await loadMovies();

--- a/style.css
+++ b/style.css
@@ -2418,6 +2418,30 @@ h2 {
   font-size: 1.1rem;
 }
 
+.movie-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.movie-controls label {
+  font-weight: 600;
+}
+
+.movie-controls select {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+}
+
+.movie-rating {
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+}
+
 .movie-meta {
   list-style: none;
   padding: 0;

--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -30,6 +30,14 @@ function buildDom() {
       <div id="savedMoviesList"></div>
     </div>
     <div id="watchedMoviesSection" style="display:none">
+      <div id="watchedMoviesControls" class="movie-controls">
+        <label for="watchedMoviesSort">Sort by:</label>
+        <select id="watchedMoviesSort">
+          <option value="recent">Recently Updated</option>
+          <option value="ratingDesc">Rating: High to Low</option>
+          <option value="ratingAsc">Rating: Low to High</option>
+        </select>
+      </div>
       <div id="watchedMoviesList"></div>
     </div>
     <div id="movieList"></div>
@@ -371,14 +379,96 @@ describe('initMoviesPanel', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(document.querySelector('#watchedMoviesList').textContent).toContain('Classic Film');
+    const ratingText = document.querySelector('#watchedMoviesList .movie-rating')?.textContent || '';
+    expect(ratingText).toContain('Rating: 9.1');
+    expect(ratingText).toContain('900 votes');
     const watchedMeta = document.querySelector('#watchedMoviesList .movie-meta')?.textContent || '';
     expect(watchedMeta).toContain('Genres: Adventure');
-    
+    expect(watchedMeta).toContain('Average Score: 9.1');
+    expect(watchedMeta).toContain('Release Date: 1999-07-16');
+
     const removeBtn = document.querySelector('#watchedMoviesList button');
     removeBtn?.click();
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(document.querySelector('#movieList').textContent).toContain('Classic Film');
+  });
+
+  it('sorts watched movies by rating when selected', async () => {
+    const dom = buildDom();
+    attachWindow(dom);
+    window.tmdbApiKey = 'TEST_KEY';
+
+    const page = {
+      results: [
+        {
+          id: 20,
+          title: 'Low Rated',
+          release_date: '2020-01-01',
+          vote_average: 7.4,
+          vote_count: 200,
+          overview: 'Solid enough.',
+          genre_ids: []
+        },
+        {
+          id: 21,
+          title: 'High Rated',
+          release_date: '2021-05-10',
+          vote_average: 9.4,
+          vote_count: 850,
+          overview: 'Critically acclaimed.',
+          genre_ids: []
+        }
+      ],
+      total_pages: 1
+    };
+    const creditsA = { cast: [], crew: [] };
+    const creditsB = { cast: [], crew: [] };
+    const genres = { genres: [] };
+
+    configureFetchResponses([page, creditsA, creditsB, genres]);
+
+    await initMoviesPanel();
+
+    const cards = Array.from(document.querySelectorAll('#movieList li'));
+    const lowCard = cards.find(card => card.textContent.includes('Low Rated'));
+    const highCard = cards.find(card => card.textContent.includes('High Rated'));
+    const lowWatch = lowCard
+      ? Array.from(lowCard.querySelectorAll('button')).find(b => b.textContent === 'Watched Already')
+      : null;
+    const highWatch = highCard
+      ? Array.from(highCard.querySelectorAll('button')).find(b => b.textContent === 'Watched Already')
+      : null;
+
+    expect(lowWatch).toBeTruthy();
+    expect(highWatch).toBeTruthy();
+
+    lowWatch?.click();
+    highWatch?.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(document.querySelectorAll('#watchedMoviesList .movie-card')).toHaveLength(2);
+
+    const sortSelect = document.getElementById('watchedMoviesSort');
+    sortSelect.value = 'ratingDesc';
+    sortSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const titlesDesc = Array.from(
+      document.querySelectorAll('#watchedMoviesList .movie-card h3')
+    ).map(el => el.textContent);
+    expect(titlesDesc[0]).toContain('High Rated');
+    expect(titlesDesc[1]).toContain('Low Rated');
+
+    sortSelect.value = 'ratingAsc';
+    sortSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const titlesAsc = Array.from(
+      document.querySelectorAll('#watchedMoviesList .movie-card h3')
+    ).map(el => el.textContent);
+    expect(titlesAsc[0]).toContain('Low Rated');
+    expect(titlesAsc[1]).toContain('High Rated');
   });
 
   it('saves preferences to Firestore for authenticated users', async () => {


### PR DESCRIPTION
## Summary
- add a watched movies toolbar with a rating-focused sort selector and supporting styles
- display TMDB ratings for watched entries and allow sorting by rating or recency
- cover the new UI behavior with updated unit tests for watched movie rendering and sorting

## Testing
- npm test -- movies

------
https://chatgpt.com/codex/tasks/task_e_68e43af0866c83279c0b91d2efb61c40