### PR TITLE
Ensure saved and watched movies show cast and director metadata

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -163,6 +163,14 @@ function persistApiKey(key) {
   }
 }
 
+function resolveApiKey() {
+  if (activeApiKey) {
+    return activeApiKey;
+  }
+  const value = domRefs.apiKeyInput?.value;
+  return typeof value === 'string' ? value.trim() : '';
+}
+
 function getTmdbProxyEndpoint() {
   if (proxyDisabled) return '';
   if (typeof window !== 'undefined' && window.tmdbProxyEndpoint) {
@@ -408,6 +416,18 @@ async function enrichMoviesWithCredits(movies, options) {
 
 async function setStatus(movie, status, options = {}) {
   if (!movie || movie.id == null) return;
+  const usingProxy = Boolean(getTmdbProxyEndpoint());
+  const apiKey = resolveApiKey();
+  if (!getNameList(movie.directors).length || !getNameList(movie.topCast).length) {
+    if (usingProxy || apiKey) {
+      try {
+        const credits = await fetchCreditsForMovie(movie.id, { usingProxy, apiKey });
+        applyCreditsToMovie(movie, credits);
+      } catch (err) {
+        console.warn('Failed to enrich movie credits before saving status', movie.id, err);
+      }
+    }
+  }
   await loadPreferences();
   const id = String(movie.id);
   const next = { ...currentPrefs };

--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -295,6 +295,7 @@ describe('initMoviesPanel', () => {
     const meta = document.querySelector('#savedMoviesList .movie-meta')?.textContent || '';
     expect(meta).toContain('Genres: Drama');
     expect(meta).toContain('Director: Indie Director');
+    expect(meta).toContain('Cast: Breakout Star');
   });
 
   it('routes movie requests through the Cloud Function proxy', async () => {
@@ -423,6 +424,8 @@ describe('initMoviesPanel', () => {
     expect(document.querySelector('#watchedMoviesList').textContent).toContain('Classic Film');
     const watchedMeta = document.querySelector('#watchedMoviesList .movie-meta')?.textContent || '';
     expect(watchedMeta).toContain('Genres: Adventure');
+    expect(watchedMeta).toContain('Director: Famed Director');
+    expect(watchedMeta).toContain('Cast: Iconic Star');
     
     const removeBtn = document.querySelector('#watchedMoviesList button');
     removeBtn?.click();


### PR DESCRIPTION
## Summary
- ensure movie snapshots resolve an API key before fetching supplemental credits data
- fetch credits when saving movie status so saved and watched lists include cast and director metadata
- extend movies panel tests to assert the saved and watched sections render cast and director details

## Testing
- npm test -- movies

------
https://chatgpt.com/codex/tasks/task_e_68e43c9cae248327b5a1853a56b96b53