### PR TITLE
Improve movie feed refetching when empty

### DIFF
--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -57,11 +57,24 @@ function attachWindow(dom) {
 }
 
 function configureFetchResponses(responses) {
-  global.fetch = vi.fn();
-  responses.forEach(res => {
-    global.fetch.mockResolvedValueOnce({
+  const queue = Array.isArray(responses) ? [...responses] : [];
+  const fallback = queue.length ? queue[queue.length - 1] : {};
+  global.fetch = vi.fn().mockImplementation(() => {
+    const next = queue.length ? queue.shift() : fallback;
+    if (next && typeof next === 'object' && 'ok' in next && typeof next.ok === 'boolean') {
+      const { ok, json } = next;
+      if (typeof json === 'function') {
+        return Promise.resolve({ ok, json });
+      }
+      const payload = { ...next };
+      return Promise.resolve({
+        ok,
+        json: () => Promise.resolve(payload.jsonPayload ?? payload.body ?? payload.data ?? {})
+      });
+    }
+    return Promise.resolve({
       ok: true,
-      json: () => Promise.resolve(res)
+      json: () => Promise.resolve(next ?? {})
     });
   });
 }
@@ -181,8 +194,38 @@ describe('initMoviesPanel', () => {
       crew: [{ job: 'Director', name: 'Visionary Director' }]
     };
     const genres = { genres: [] };
+    const morePage = {
+      results: [
+        {
+          id: 10,
+          title: 'Another Remote Pick',
+          release_date: '2024-05-05',
+          vote_average: 7.5,
+          vote_count: 95,
+          overview: 'Extra selection.',
+          genre_ids: []
+        }
+      ]
+    };
+    const moreCredits = {
+      cast: [{ name: 'Backup Star' }],
+      crew: [{ job: 'Director', name: 'Backup Director' }]
+    };
 
-    configureFetchResponses([page, empty, credits, genres]);
+    configureFetchResponses([
+      page,
+      empty,
+      credits,
+      genres,
+      morePage,
+      empty,
+      moreCredits,
+      genres,
+      morePage,
+      empty,
+      moreCredits,
+      genres
+    ]);
 
     await initMoviesPanel();
 
@@ -265,8 +308,34 @@ describe('initMoviesPanel', () => {
       crew: [{ job: 'Director', name: 'Indie Director' }]
     };
     const genres = { genres: [{ id: 18, name: 'Drama' }] };
+    const morePage = {
+      results: [
+        {
+          id: 3,
+          title: 'Next Up',
+          release_date: '2023-11-10',
+          vote_average: 7.9,
+          vote_count: 110,
+          overview: 'Another great option.',
+          genre_ids: [18]
+        }
+      ]
+    };
+    const moreCredits = {
+      cast: [{ name: 'Another Star' }],
+      crew: [{ job: 'Director', name: 'New Director' }]
+    };
 
-    configureFetchResponses([page, empty, credits, genres]);
+    configureFetchResponses([
+      page,
+      empty,
+      credits,
+      genres,
+      morePage,
+      empty,
+      moreCredits,
+      genres
+    ]);
 
     await initMoviesPanel();
 
@@ -275,8 +344,9 @@ describe('initMoviesPanel', () => {
     );
     interestedBtn?.click();
     await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(document.querySelector('#movieList').textContent).toContain('No new movies right now.');
+    expect(document.querySelector('#movieList').textContent).toContain('Next Up');
     const slider = document.querySelector('#savedMoviesList input[type="range"]');
     expect(slider).not.toBeNull();
     expect(slider.value).toBe('3');
@@ -359,8 +429,34 @@ describe('initMoviesPanel', () => {
       crew: [{ job: 'Director', name: 'Famed Director' }]
     };
     const genres = { genres: [{ id: 12, name: 'Adventure' }] };
+    const morePage = {
+      results: [
+        {
+          id: 8,
+          title: 'Fresh Release',
+          release_date: '2024-02-20',
+          vote_average: 8.4,
+          vote_count: 210,
+          overview: 'A brand new hit.',
+          genre_ids: [12]
+        }
+      ]
+    };
+    const moreCredits = {
+      cast: [{ name: 'Newcomer Star' }],
+      crew: [{ job: 'Director', name: 'Rising Director' }]
+    };
 
-    configureFetchResponses([page, empty, credits, genres]);
+    configureFetchResponses([
+      page,
+      empty,
+      credits,
+      genres,
+      morePage,
+      empty,
+      moreCredits,
+      genres
+    ]);
 
     await initMoviesPanel();
 
@@ -369,6 +465,7 @@ describe('initMoviesPanel', () => {
     );
     watchedBtn?.click();
     await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(document.querySelector('#watchedMoviesList').textContent).toContain('Classic Film');
     const watchedMeta = document.querySelector('#watchedMoviesList .movie-meta')?.textContent || '';
@@ -376,6 +473,7 @@ describe('initMoviesPanel', () => {
     
     const removeBtn = document.querySelector('#watchedMoviesList button');
     removeBtn?.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(document.querySelector('#movieList').textContent).toContain('Classic Film');
@@ -418,6 +516,7 @@ describe('initMoviesPanel', () => {
       b => b.textContent === 'Interested'
     );
     interestedBtn?.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(firestoreDocMock.set).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- automatically refresh the movie feed when all visible entries are cleared by tracking suppressed statuses and reloading from TMDB
- reintroduce cleared movies into the feed when preferences are removed and expand discovery to skip previously suppressed picks
- update movie panel tests and fetch helpers to cover the new reload behaviour and additional API calls

## Testing
- npx vitest run tests/movies.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e43a99ea088327ad0a8898f323d54e