### PR TITLE
Use Spoonacular proxy exclusively for recipes

### DIFF
--- a/README copy.md
+++ b/README copy.md
@@ -45,6 +45,6 @@ npm test
 
 ### Recipes API
 
-The app first tries to query the hosted Spoonacular proxy at `/api/spoonacular` (or `/spoonacularProxy` when using the Cloud Functions deployment). If the proxy cannot be reached, you can supply an [API Ninjas Recipe API](https://api-ninjas.com/api/recipe) key in the Recipes tab and the app will call their endpoint directly. The key is stored only in your browser's local storage so you do not need to re-enter it on every visit.
+The recipes tab queries the hosted Spoonacular proxy at `/api/spoonacular` (or `/spoonacularProxy` when using the Cloud Functions deployment). The proxy requires a Spoonacular API key to be configured on the server or Cloud Function.
 
 To run the proxy locally, create a `.env` file with `SPOONACULAR_KEY=your_api_key_here` and restart the server with `npm start`.

--- a/index.html
+++ b/index.html
@@ -118,17 +118,11 @@
           </div>
           <div id="recipesForm" style="margin-bottom:1rem;">
             <input type="text" id="recipesQuery" placeholder="Search (e.g. chicken)" style="margin-right:.5rem;">
-            <div id="recipesApiKeyContainer" style="display:inline-block;">
-              <input type="text" id="recipesApiKey" placeholder="API Key" style="margin-right:.5rem;">
-              <div id="recipesApiKeyInstructions" style="font-size:0.8rem;margin-top:0.5rem;">
-                Get a free API key from <a href="https://api-ninjas.com/profile" target="_blank" rel="noopener noreferrer">API Ninjas</a>.
-              </div>
-            </div>
             <button type="button" id="recipesSearchBtn" aria-label="Search recipes">Search</button>
           </div>
           <div id="recipesList" class="decision-container"></div>
           <div style="font-size:0.8rem;margin-top:0.5rem;">
-            Uses the <a href="https://api-ninjas.com/api/recipe" target="_blank" rel="noopener noreferrer">API Ninjas Recipe API</a>.
+            Uses the <a href="https://spoonacular.com/food-api" target="_blank" rel="noopener noreferrer">Spoonacular Recipe API</a>.
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the API Ninjas fallback and related UI from the recipes panel
- always request recipes through the Spoonacular proxy and update error guidance
- refresh documentation and tests to reflect the Spoonacular-only flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e43ddb45a08327a3d558642b67a793