### PR TITLE
Add personal ratings for watched movies

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -47,6 +47,13 @@ const handlers = {
   handleChange: null
 };
 
+function clampUserRating(value) {
+  if (!Number.isFinite(value)) return null;
+  if (value < 0) return 0;
+  if (value > 10) return 10;
+  return Math.round(value * 2) / 2;
+}
+
 function getNameList(input) {
   if (!input) return [];
 
@@ -393,6 +400,42 @@ function createRatingElement(movie) {
   return ratingEl;
 }
 
+function createUserRatingElement(pref) {
+  if (!pref || !pref.movie) return null;
+
+  const container = document.createElement('label');
+  container.className = 'movie-personal-rating';
+  container.textContent = 'Your Rating: ';
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '0';
+  input.max = '10';
+  input.step = '0.5';
+  input.inputMode = 'decimal';
+  input.placeholder = '—';
+
+  if (pref.userRating != null && pref.userRating !== '') {
+    const rating = clampUserRating(Number(pref.userRating));
+    if (rating != null) {
+      input.value = rating.toString();
+    }
+  }
+
+  input.addEventListener('change', event => {
+    const value = Number.parseFloat(event.target.value);
+    if (Number.isNaN(value)) {
+      setUserRating(pref.movie.id, null);
+      return;
+    }
+    setUserRating(pref.movie.id, value);
+  });
+
+  container.appendChild(input);
+
+  return container;
+}
+
 function applyCreditsToMovie(movie, credits) {
   if (!movie || !credits) return;
   const cast = Array.isArray(credits.cast) ? credits.cast : [];
@@ -513,13 +556,35 @@ async function setStatus(movie, status, options = {}) {
   if (status === 'interested') {
     entry.interest = options.interest ?? entry.interest ?? DEFAULT_INTEREST;
     entry.movie = snapshot;
+    delete entry.userRating;
   } else if (status === 'watched') {
     entry.movie = snapshot;
     delete entry.interest;
   } else if (status === 'notInterested') {
     delete entry.movie;
     delete entry.interest;
+    delete entry.userRating;
   }
+  next[id] = entry;
+  await savePreferences(next);
+  refreshUI();
+}
+
+async function setUserRating(movieId, rating) {
+  await loadPreferences();
+  const id = String(movieId);
+  const pref = currentPrefs[id];
+  if (!pref || pref.status !== 'watched') return;
+
+  const next = { ...currentPrefs };
+  const entry = { ...pref };
+
+  if (rating == null) {
+    delete entry.userRating;
+  } else {
+    entry.userRating = clampUserRating(rating);
+  }
+  entry.updatedAt = Date.now();
   next[id] = entry;
   await savePreferences(next);
   refreshUI();
@@ -741,9 +806,17 @@ function renderWatchedList() {
   const sorted = entries.slice();
 
   const byUpdatedAt = (a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
+  const getEffectiveRating = pref => {
+    if (pref.userRating != null) {
+      const rating = clampUserRating(Number(pref.userRating));
+      if (rating != null) return rating;
+    }
+    return getVoteAverageValue(pref.movie);
+  };
+
   const byRatingDesc = (a, b) => {
-    const aRating = getVoteAverageValue(a.movie);
-    const bRating = getVoteAverageValue(b.movie);
+    const aRating = getEffectiveRating(a);
+    const bRating = getEffectiveRating(b);
     if (aRating == null && bRating == null) return byUpdatedAt(a, b);
     if (aRating == null) return 1;
     if (bRating == null) return -1;
@@ -757,8 +830,8 @@ function renderWatchedList() {
     return byUpdatedAt(a, b);
   };
   const byRatingAsc = (a, b) => {
-    const aRating = getVoteAverageValue(a.movie);
-    const bRating = getVoteAverageValue(b.movie);
+    const aRating = getEffectiveRating(a);
+    const bRating = getEffectiveRating(b);
     if (aRating == null && bRating == null) return byUpdatedAt(a, b);
     if (aRating == null) return 1;
     if (bRating == null) return -1;
@@ -813,6 +886,11 @@ function renderWatchedList() {
     const ratingEl = createRatingElement(movie);
     if (ratingEl) {
       info.appendChild(ratingEl);
+    }
+
+    const personalRatingEl = createUserRatingElement(pref);
+    if (personalRatingEl) {
+      info.appendChild(personalRatingEl);
     }
 
     if (movie.overview) {

--- a/style.css
+++ b/style.css
@@ -2464,6 +2464,22 @@ h2 {
   margin: 0 0 0.5rem 0;
 }
 
+.movie-personal-rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem 0;
+}
+
+.movie-personal-rating input {
+  width: 4rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-weight: 500;
+}
+
 .movie-meta {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- allow users to save a personal rating on watched movies and persist it with preferences
- surface a rating input in the watched list and include user ratings when sorting by rating
- style the new personal rating control to match existing movie card elements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e43e4b04ac8327a293cde99590aabb