### PR TITLE
Add configurable filters to movie feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,59 @@
             <button class="movie-tab" data-target="watchedMoviesSection">Watched Movies</button>
           </div>
           <div id="movieStreamSection">
+            <div id="movieFeedControls" class="movie-controls movie-filter-controls">
+              <div class="movie-filter-field">
+                <label for="movieFilterMinRating">Min Rating</label>
+                <input
+                  type="number"
+                  id="movieFilterMinRating"
+                  name="movieFilterMinRating"
+                  min="0"
+                  max="10"
+                  step="0.1"
+                  inputmode="decimal"
+                  placeholder="e.g. 7"
+                />
+              </div>
+              <div class="movie-filter-field">
+                <label for="movieFilterMinVotes">Min Votes</label>
+                <input
+                  type="number"
+                  id="movieFilterMinVotes"
+                  name="movieFilterMinVotes"
+                  min="0"
+                  step="1"
+                  inputmode="numeric"
+                  placeholder="e.g. 100"
+                />
+              </div>
+              <div class="movie-filter-field">
+                <label for="movieFilterStartYear">Earliest Year</label>
+                <input
+                  type="number"
+                  id="movieFilterStartYear"
+                  name="movieFilterStartYear"
+                  inputmode="numeric"
+                  placeholder="e.g. 2010"
+                />
+              </div>
+              <div class="movie-filter-field">
+                <label for="movieFilterEndYear">Latest Year</label>
+                <input
+                  type="number"
+                  id="movieFilterEndYear"
+                  name="movieFilterEndYear"
+                  inputmode="numeric"
+                  placeholder="e.g. 2024"
+                />
+              </div>
+              <div class="movie-filter-field">
+                <label for="movieFilterGenre">Genre</label>
+                <select id="movieFilterGenre" name="movieFilterGenre">
+                  <option value="">All Genres</option>
+                </select>
+              </div>
+            </div>
             <div id="movieList" class="decision-container"></div>
           </div>
           <div id="savedMoviesSection" style="display:none;">

--- a/style.css
+++ b/style.css
@@ -2495,6 +2495,10 @@ h2 {
   flex-wrap: wrap;
 }
 
+.movie-filter-controls {
+  align-items: flex-end;
+}
+
 .movie-controls label {
   font-weight: 600;
 }
@@ -2504,6 +2508,29 @@ h2 {
   border-radius: 4px;
   border: 1px solid #ccc;
   background: #fff;
+}
+
+.movie-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.movie-filter-field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.movie-filter-field input,
+.movie-filter-field select {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+}
+
+.movie-filter-field input {
+  min-width: 6.5rem;
 }
 
 .movie-rating {


### PR DESCRIPTION
## Summary
- add UI controls to the movie stream tab for filtering by rating, votes, release year, and genre
- persist movie feed filter preferences and apply them to the fetched results before rendering
- style the new filter controls to align with the existing movie layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e43f1bc0f08327a22b9f5707d16b77