### PR TITLE
Adjust recipes API base URL fallback

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -1,8 +1,51 @@
-const API_BASE_URL =
-  (typeof window !== 'undefined' && window.apiBaseUrl) ||
-  (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
-  (typeof window !== 'undefined' && window.location?.origin) ||
+const DEFAULT_CLOUD_FUNCTION_BASE =
   'https://us-central1-decision-maker-4e1d3.cloudfunctions.net';
+
+const isLikelyLocalHost = hostname => {
+  if (!hostname || typeof hostname !== 'string') return false;
+  const normalized = hostname.trim().toLowerCase();
+  if (!normalized) return false;
+  if (['localhost', '127.0.0.1', '::1'].includes(normalized)) return true;
+  return (
+    normalized.endsWith('.local') ||
+    normalized.startsWith('192.168.') ||
+    normalized.startsWith('10.') ||
+    normalized.startsWith('172.16.') ||
+    normalized.startsWith('172.17.') ||
+    normalized.startsWith('172.18.') ||
+    normalized.startsWith('172.19.') ||
+    normalized.startsWith('172.20.') ||
+    normalized.startsWith('172.21.') ||
+    normalized.startsWith('172.22.') ||
+    normalized.startsWith('172.23.') ||
+    normalized.startsWith('172.24.') ||
+    normalized.startsWith('172.25.') ||
+    normalized.startsWith('172.26.') ||
+    normalized.startsWith('172.27.') ||
+    normalized.startsWith('172.28.') ||
+    normalized.startsWith('172.29.') ||
+    normalized.startsWith('172.30.') ||
+    normalized.startsWith('172.31.')
+  );
+};
+
+const resolveApiBaseUrl = () => {
+  if (typeof window !== 'undefined' && window.apiBaseUrl) {
+    return window.apiBaseUrl;
+  }
+  if (typeof process !== 'undefined' && process.env.API_BASE_URL) {
+    return process.env.API_BASE_URL;
+  }
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    const { origin, hostname } = window.location;
+    if (isLikelyLocalHost(hostname)) {
+      return origin;
+    }
+  }
+  return DEFAULT_CLOUD_FUNCTION_BASE;
+};
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 const stripHtml = text =>
   typeof text === 'string'


### PR DESCRIPTION
## Summary
- update the recipes panel API base URL resolution to prefer the hosted Cloud Function when not on a local host
- add a helper to detect local hostnames so the recipes proxy works out of the box in production deployments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4415a44ac8327a8b8bdb1a10b0c5f