### PR TITLE
Improve Live Music discovery experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,10 +145,23 @@
           </div>
           <div id="ticketmasterForm" style="margin-bottom:1rem;">
             <button type="button" id="spotifyTokenBtn" style="margin-right:.5rem;">Login to Spotify</button>
-            <span id="spotifyStatus" style="margin-right:.5rem;"></span>
-            <input type="password" id="spotifyToken" placeholder="Spotify Access Token" style="margin-right:.5rem;">
+            <span id="spotifyStatus" class="shows-status" style="margin-right:.5rem;"></span>
             <input type="password" id="ticketmasterApiKey" placeholder="Ticketmaster API Key" style="margin-right:.5rem;">
             <button type="button" id="ticketmasterDiscoverBtn" class="shows-discover-btn">Discover</button>
+          </div>
+          <div id="showsConfigControls" class="shows-config">
+            <div class="shows-config__field">
+              <label for="showsRadius">Search radius (miles)</label>
+              <input type="number" id="showsRadius" min="25" max="1000" step="25" value="300" inputmode="numeric">
+            </div>
+            <div class="shows-config__field">
+              <label for="showsArtistLimit">Top artists to scan</label>
+              <input type="number" id="showsArtistLimit" min="1" max="50" step="1" value="10" inputmode="numeric">
+            </div>
+            <label class="shows-config__toggle" for="showsIncludeSuggestions">
+              <input type="checkbox" id="showsIncludeSuggestions" checked>
+              <span>Show Spotify recommendations when no events are nearby</span>
+            </label>
           </div>
           <div id="showsTabs" class="movie-tabs">
             <button type="button" class="movie-tab shows-tab active" data-target="showsFeedSection">Discover</button>

--- a/style.css
+++ b/style.css
@@ -598,6 +598,63 @@ button:hover {
   box-shadow: none;
 }
 
+.shows-config {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e1ebe4;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.75);
+  margin-bottom: 1.5rem;
+}
+
+.shows-config__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.shows-config__field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #5a6f63;
+}
+
+.shows-config__field input[type='number'] {
+  border: 1px solid #d7e5dd;
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.95rem;
+  background: #ffffff;
+  color: #2f3c35;
+}
+
+.shows-config__field input[type='number']:focus {
+  outline: none;
+  border-color: #7aa68c;
+  box-shadow: 0 0 0 3px rgba(122, 166, 140, 0.25);
+}
+
+.shows-config__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #2f3c35;
+}
+
+.shows-config__toggle input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #7aa68c;
+}
+
+.shows-status {
+  font-size: 0.9rem;
+  color: #5a6f63;
+}
+
 .shows-grid {
   list-style: none;
   display: grid;
@@ -605,6 +662,10 @@ button:hover {
   gap: 1.25rem;
   padding: 0;
   margin: 0;
+}
+
+.shows-grid--preview {
+  margin-top: 1rem;
 }
 
 .show-card {
@@ -621,6 +682,17 @@ button:hover {
 .show-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 14px 28px rgba(25, 55, 45, 0.14);
+}
+
+.show-card--sample {
+  opacity: 0.95;
+}
+
+.show-card--sample .show-card__cta {
+  pointer-events: none;
+  background: #d7e5dd;
+  color: #5a6f63;
+  cursor: not-allowed;
 }
 
 .show-card__media {
@@ -687,6 +759,13 @@ button:hover {
   gap: 0.4rem;
 }
 
+.show-card__sample-note {
+  margin-top: 0.65rem;
+  font-size: 0.85rem;
+  color: #47695f;
+  text-align: left;
+}
+
 .show-card__status {
   align-self: flex-start;
   background: linear-gradient(135deg, #2f7f70, #3fa284);
@@ -715,6 +794,16 @@ button:hover {
   background: linear-gradient(135deg, #2f7f70, #3fa284);
   color: #ffffff;
   transition: filter 0.2s ease, transform 0.2s ease;
+}
+
+.show-card__button[disabled],
+.show-card__button--disabled {
+  background: #d7e5dd;
+  color: #5a6f63;
+  cursor: not-allowed;
+  box-shadow: none;
+  filter: none;
+  transform: none;
 }
 
 .show-card__button:hover {
@@ -813,6 +902,13 @@ button:hover {
   border-radius: 12px;
   text-align: center;
   font-weight: 600;
+}
+
+.shows-preview-note {
+  margin: 0.75rem 0 0;
+  color: #35584e;
+  font-weight: 600;
+  text-align: center;
 }
 
 .shows-suggestions {


### PR DESCRIPTION
## Summary
- remove the manual Spotify token field, expose configuration controls, and surface login status messaging in the Live Music tab
- refactor the shows discovery flow to persist settings, offer preview cards, and integrate OAuth plus Ticketmaster fetch updates
- update the Live Music Vitest suite for the new UI flows and configuration persistence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e51fae8e108327b77f45ea23f93187