### PR TITLE
Display Spoonacular ingredient preview in recipe cards

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -357,6 +357,18 @@ export async function initRecipesPanel() {
           card.appendChild(figure);
         }
 
+        if (recipe.ingredients.length) {
+          const preview = document.createElement('p');
+          preview.className = 'recipe-card__ingredient-preview';
+          const previewItems = recipe.ingredients.slice(0, 5);
+          const previewText = previewItems.join(', ');
+          const hasMore = recipe.ingredients.length > previewItems.length;
+          preview.textContent = hasMore
+            ? `Key ingredients: ${previewText}\u2026`
+            : `Key ingredients: ${previewText}`;
+          card.appendChild(preview);
+        }
+
         if (recipe.summary) {
           const summaryWrap = document.createElement('div');
           summaryWrap.className = 'recipe-card__summary-wrap';

--- a/style.css
+++ b/style.css
@@ -3225,6 +3225,13 @@ h2 {
   color: #453c2f;
 }
 
+.recipe-card__ingredient-preview {
+  margin: 0.65rem 0 0.55rem 0;
+  font-size: 0.9rem;
+  color: #4a3d2a;
+  font-weight: 500;
+}
+
 .recipe-card__ingredients,
 .recipe-card__steps {
   margin: 0;

--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -77,6 +77,9 @@ describe('initRecipesPanel', () => {
     const cards = document.querySelectorAll('#recipesList .recipe-card');
     expect(cards.length).toBe(2);
 
+    const preview = cards[0].querySelector('.recipe-card__ingredient-preview');
+    expect(preview.textContent).toBe('Key ingredients: chicken, water');
+
     const summary = cards[0].querySelector('.recipe-card__summary').textContent;
     expect(summary).toBe('Rich soup');
 


### PR DESCRIPTION
## Summary
- add a key ingredient preview line to recipe cards sourced from Spoonacular results
- style the preview for visual emphasis above the detailed ingredient list
- extend the recipes panel tests to cover the new preview text

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5202d794c8327a1ab6eeeada629e7