### PR TITLE
Use black text on movie filter buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -2372,12 +2372,13 @@ h2 {
   padding: 4px 12px;
   cursor: pointer;
   font-size: 0.9rem;
+  color: #000;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .genre-filter-btn.active {
   background: #7aa68c;
-  color: #fff;
+  color: #000;
   border-color: #7aa68c;
 }
 


### PR DESCRIPTION
## Summary
- set movie genre filter buttons to use black text in both default and active states for better readability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e52d085b088327b31e4df21ef1af83