### PR TITLE
Refine restaurants UI and filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,10 +213,22 @@
               <legend id="restaurantsFiltersLegend">Filter restaurants</legend>
               <label class="restaurants-filters__label" for="restaurantsDistanceSelect">Within</label>
               <select id="restaurantsDistanceSelect" class="restaurants-filters__control">
+                <option value="1">1 mile</option>
+                <option value="2">2 miles</option>
+                <option value="3">3 miles</option>
+                <option value="4">4 miles</option>
                 <option value="5">5 miles</option>
+                <option value="6">6 miles</option>
+                <option value="7">7 miles</option>
+                <option value="8">8 miles</option>
+                <option value="9">9 miles</option>
                 <option value="10">10 miles</option>
+                <option value="15">15 miles</option>
+                <option value="20">20 miles</option>
                 <option value="25" selected>25 miles</option>
+                <option value="35">35 miles</option>
                 <option value="50">50 miles</option>
+                <option value="75">75 miles</option>
                 <option value="100">100 miles</option>
               </select>
             </fieldset>

--- a/style.css
+++ b/style.css
@@ -2802,6 +2802,16 @@ h2 {
   color: #1f3631;
 }
 
+.restaurant-card__title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.restaurant-card__title-link:hover,
+.restaurant-card__title-link:focus {
+  text-decoration: underline;
+}
+
 .rating-badge {
   display: inline-flex;
   align-items: center;

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -11,10 +11,22 @@ function setupDom() {
           <fieldset>
             <label for="restaurantsDistanceSelect">Within</label>
             <select id="restaurantsDistanceSelect">
+              <option value="1">1 mile</option>
+              <option value="2">2 miles</option>
+              <option value="3">3 miles</option>
+              <option value="4">4 miles</option>
               <option value="5">5 miles</option>
+              <option value="6">6 miles</option>
+              <option value="7">7 miles</option>
+              <option value="8">8 miles</option>
+              <option value="9">9 miles</option>
               <option value="10">10 miles</option>
+              <option value="15">15 miles</option>
+              <option value="20">20 miles</option>
               <option value="25" selected>25 miles</option>
+              <option value="35">35 miles</option>
               <option value="50">50 miles</option>
+              <option value="75">75 miles</option>
               <option value="100">100 miles</option>
             </select>
           </fieldset>


### PR DESCRIPTION
## Summary
- link restaurant names directly to Yelp and remove the redundant Yelp, directions, and call buttons
- surface additional restaurant metadata including phone, reviews, and distance with light styling updates
- expand the distance selector to 1-mile granularity and update tests to match

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e530216cd48327b6e48f77e82104d5