### PR TITLE
Handle nutrition ingredient data when rendering recipes

### DIFF
--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -106,6 +106,40 @@ describe('initRecipesPanel', () => {
     expect(tagChip.textContent).toBe('American');
   });
 
+  it('displays ingredient section when only nutrition ingredient data is available', async () => {
+    const mockResponse = {
+      results: [
+        {
+          title: 'Carrot Salad',
+          nutrition: {
+            ingredients: [
+              { name: 'carrot', amount: 2, unit: 'cups' },
+              { original: '1 tsp salt' }
+            ]
+          },
+          analyzedInstructions: [{ steps: [{ step: 'mix' }] }]
+        }
+      ]
+    };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      })
+    );
+
+    await initRecipesPanel();
+    document.getElementById('recipesQuery').value = 'carrot';
+    document.getElementById('recipesSearchBtn').click();
+    await new Promise(r => setTimeout(r, 0));
+
+    const ingredientItems = document.querySelectorAll('.recipe-card__ingredients li');
+    expect(Array.from(ingredientItems).map(el => el.textContent)).toEqual([
+      '2 cups carrot',
+      '1 tsp salt'
+    ]);
+  });
+
   it('allows expanding long summaries', async () => {
     const mockResponse = {
       results: [


### PR DESCRIPTION
## Summary
- expand recipe ingredient parsing to pull from extended ingredients, ingredient lines, and nutrition ingredient data while deduplicating entries
- normalize text values so recipes always render a dedicated ingredients section populated from every available source
- add a regression test to cover the nutrition-only ingredient scenario

## Testing
- npx vitest run tests/recipes.test.js
- vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e531ac77188327b202b4749f240f0e