### PR TITLE
Clarify missing recipe ingredients messaging

### DIFF
--- a/style.css
+++ b/style.css
@@ -3305,6 +3305,12 @@ h2 {
   font-weight: 500;
 }
 
+.recipe-card__ingredients-empty {
+  margin: 0;
+  color: #544c3a;
+  font-style: italic;
+}
+
 .recipe-card__ingredients,
 .recipe-card__steps {
   margin: 0;

--- a/tests/recipes.test.js
+++ b/tests/recipes.test.js
@@ -140,6 +140,34 @@ describe('initRecipesPanel', () => {
     ]);
   });
 
+  it('states when ingredient details are unavailable', async () => {
+    const mockResponse = {
+      results: [
+        {
+          title: 'Mystery Meal',
+          summary: 'A surprise dish'
+        }
+      ]
+    };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      })
+    );
+
+    await initRecipesPanel();
+    document.getElementById('recipesQuery').value = 'mystery';
+    document.getElementById('recipesSearchBtn').click();
+    await new Promise(r => setTimeout(r, 0));
+
+    const preview = document.querySelector('.recipe-card__ingredient-preview');
+    expect(preview.textContent).toBe('Ingredients were not provided for this recipe.');
+
+    const message = document.querySelector('.recipe-card__ingredients-empty');
+    expect(message.textContent).toBe("We couldn't retrieve the ingredient list for this recipe.");
+  });
+
   it('allows expanding long summaries', async () => {
     const mockResponse = {
       results: [


### PR DESCRIPTION
## Summary
- track when recipe results include any ingredient data and store that flag on rendered cards
- show a preview and section message explaining when ingredients are unavailable, including new styling
- add a regression test that verifies the messaging for recipes without ingredient details

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e53750146483278275aea7b0c43096