### PR TITLE
Collapse hidden restaurant list

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -15,6 +15,7 @@ const STORAGE_KEYS = {
 
 let savedRestaurants = [];
 let hiddenRestaurants = [];
+let isHiddenRestaurantsExpanded = false;
 let nearbyRestaurants = [];
 let visibleNearbyRestaurants = [];
 let rawNearbyRestaurants = [];
@@ -714,17 +715,41 @@ function renderHiddenSection() {
   container.innerHTML = '';
   if (!hiddenRestaurants.length) {
     container.classList.remove('is-visible');
+    isHiddenRestaurantsExpanded = false;
     return;
   }
 
   container.classList.add('is-visible');
 
-  const heading = document.createElement('h4');
-  heading.textContent = 'Hidden Restaurants';
-  container.appendChild(heading);
+  const count = hiddenRestaurants.length;
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'restaurants-hidden-toggle';
+  toggle.setAttribute('aria-expanded', String(isHiddenRestaurantsExpanded));
+  toggle.setAttribute('aria-controls', 'restaurantsHiddenList');
+
+  const label = document.createElement('span');
+  label.className = 'restaurants-hidden-toggle-label';
+  label.textContent = `Hidden Restaurants (${count})`;
+  toggle.appendChild(label);
+
+  const icon = document.createElement('span');
+  icon.className = 'restaurants-hidden-toggle-icon';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '▸';
+  toggle.appendChild(icon);
+
+  toggle.addEventListener('click', () => {
+    isHiddenRestaurantsExpanded = !isHiddenRestaurantsExpanded;
+    renderHiddenSection();
+  });
+
+  container.appendChild(toggle);
 
   const list = document.createElement('div');
   list.className = 'restaurants-hidden-list';
+  list.id = 'restaurantsHiddenList';
+  list.hidden = !isHiddenRestaurantsExpanded;
 
   hiddenRestaurants.forEach(rest => {
     const item = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -3036,10 +3036,33 @@ h2 {
   display: flex;
 }
 
-.restaurants-hidden h4 {
+.restaurants-hidden-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   margin: 0;
+  padding: 0.1rem 0;
   font-size: 1rem;
+  font-weight: 600;
   color: #1f3631;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.restaurants-hidden-toggle:focus-visible {
+  outline: 2px solid rgba(31, 54, 49, 0.35);
+  outline-offset: 2px;
+}
+
+.restaurants-hidden-toggle-icon {
+  transition: transform 0.2s ease;
+}
+
+.restaurants-hidden-toggle[aria-expanded='true'] .restaurants-hidden-toggle-icon {
+  transform: rotate(90deg);
 }
 
 .restaurants-hidden-list {

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -356,7 +356,19 @@ describe('initRestaurantsPanel', () => {
     expect(nearbyHeadings).toEqual(['Second Place']);
 
     const hiddenSection = document.getElementById('restaurantsHiddenSection');
-    expect(hiddenSection?.textContent).toContain('Top Rated');
     expect(hiddenSection?.classList.contains('is-visible')).toBe(true);
+
+    const toggle = hiddenSection?.querySelector('.restaurants-hidden-toggle');
+    expect(toggle?.textContent).toContain('Hidden Restaurants (1)');
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+
+    toggle?.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+    const expandedToggle = hiddenSection?.querySelector('.restaurants-hidden-toggle');
+    expect(expandedToggle?.getAttribute('aria-expanded')).toBe('true');
+
+    const list = hiddenSection?.querySelector('.restaurants-hidden-list');
+    expect(list?.hidden).toBe(false);
+    expect(list?.textContent).toContain('Top Rated');
   });
 });


### PR DESCRIPTION
## Summary
- add a toggle control to collapse and expand the hidden restaurants list
- style the hidden section header as an accessible button and hide the list when collapsed
- extend restaurants panel tests to cover the new collapsed and expanded states

## Testing
- npm test -- restaurants

------
https://chatgpt.com/codex/tasks/task_e_68e537a879248327a687e8ff6a9ace21