### PR TITLE
Move Spotify reconnect button to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,6 @@
             <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
           </div>
           <div id="ticketmasterForm" style="margin-bottom:1rem;">
-            <button type="button" id="spotifyTokenBtn" style="margin-right:.5rem;">Login to Spotify</button>
-            <span id="spotifyStatus" class="shows-status" style="margin-right:.5rem;"></span>
             <input type="password" id="ticketmasterApiKey" placeholder="Ticketmaster API Key" style="margin-right:.5rem;">
             <button type="button" id="ticketmasterDiscoverBtn" class="shows-discover-btn">Discover</button>
           </div>
@@ -172,6 +170,10 @@
           </div>
           <div id="showsInterestedSection" style="display:none;">
             <div id="ticketmasterInterestedList" class="decision-container"></div>
+          </div>
+          <div class="shows-spotify-footer">
+            <span id="spotifyStatus" class="shows-status"></span>
+            <button type="button" id="spotifyTokenBtn">Login to Spotify</button>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -655,6 +655,18 @@ button:hover {
   color: #5a6f63;
 }
 
+.shows-spotify-footer {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.shows-spotify-footer #spotifyTokenBtn {
+  margin: 0;
+}
+
 .shows-grid {
   list-style: none;
   display: grid;


### PR DESCRIPTION
## Summary
- move the Spotify reconnect/login button into a footer area at the bottom of the Live Music panel
- add styling for the new footer layout to keep the button and status aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e538457a648327abe3e6e71cf4e02c