### PR TITLE
Improve movie feed loading feedback

### DIFF
--- a/style.css
+++ b/style.css
@@ -2678,10 +2678,61 @@ h2 {
   padding: 4px 12px;
 }
 
+#movieList {
+  position: relative;
+  min-height: 4rem;
+}
+
 #movieList ul {
   list-style: none;
   padding: 0;
   margin: 0;
+}
+
+.movie-list--is-loading {
+  position: relative;
+}
+
+.movie-list--is-loading > :not(.movie-list-loading-overlay) {
+  opacity: 0.45;
+  filter: blur(0.2px);
+  transition: opacity 0.2s ease;
+}
+
+.movie-list-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 6px;
+  pointer-events: none;
+  text-align: center;
+  z-index: 2;
+}
+
+.movie-list-spinner {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid rgba(47, 107, 67, 0.25);
+  border-top-color: #2f6b43;
+  animation: movie-list-spin 0.8s linear infinite;
+}
+
+.movie-list-loading-text {
+  font-weight: 600;
+  color: #2f6b43;
+}
+
+@keyframes movie-list-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* GeoScore admin styles */


### PR DESCRIPTION
## Summary
- add a reusable helper to show an overlay spinner while the movie feed refreshes so the existing list stays visible
- mark the movie list as busy and add supporting styles for the loading overlay and spinner to clarify progress when fetching more results

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e538293d9c8327bb3262ff79992a9a