### PR TITLE
Ensure Spoonacular proxy includes ingredient details

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -440,7 +440,7 @@ app.get('/api/spoonacular', async (req, res) => {
   const apiUrl =
     `https://api.spoonacular.com/recipes/complexSearch?query=${encodeURIComponent(
       query
-    )}&number=50&offset=0&addRecipeInformation=true&apiKey=${apiKey}`;
+    )}&number=50&offset=0&addRecipeInformation=true&addRecipeNutrition=true&fillIngredients=true&apiKey=${apiKey}`;
   try {
     const apiRes = await fetch(apiUrl);
     const text = await apiRes.text();

--- a/functions/index.js
+++ b/functions/index.js
@@ -493,6 +493,8 @@ exports.spoonacularProxy = functions
       number: '50',
       offset: '0',
       addRecipeInformation: 'true',
+      addRecipeNutrition: 'true',
+      fillIngredients: 'true',
       apiKey
     });
 


### PR DESCRIPTION
## Summary
- request complete ingredient information from Spoonacular by including addRecipeNutrition and fillIngredients in both proxy implementations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e53a18c92483278440f2d3b5960450