### PR TITLE
Add pagination for Spotify top artists

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
             </div>
             <div class="shows-config__field">
               <label for="showsArtistLimit">Top artists to scan</label>
-              <input type="number" id="showsArtistLimit" min="1" max="50" step="1" value="10" inputmode="numeric">
+              <input type="number" id="showsArtistLimit" min="1" max="200" step="1" value="10" inputmode="numeric">
             </div>
             <label class="shows-config__toggle" for="showsIncludeSuggestions">
               <input type="checkbox" id="showsIncludeSuggestions" checked>


### PR DESCRIPTION
## Summary
- allow selecting up to 200 artists in the shows panel configuration
- paginate Spotify top artist requests so larger limits fetch every page while preserving session handling
- cover the new pagination logic with a regression test

## Testing
- npx vitest run tests/showsSpotify.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e53b8899a083279be280a6c55c06b5