### PR TITLE
Align Songkick caches with 24-hour window

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dashboard is a personal decision-making and entertainment hub that brings movie 
 - [How the Live Music Discover Flow Works](#how-the-live-music-discover-flow-works)
   - [Spotify endpoints in use](#spotify-endpoints-in-use)
   - [Using liked songs instead of top artists](#using-liked-songs-instead-of-top-artists)
-  - [Ticketmaster integration](#ticketmaster-integration)
+  - [Songkick integration](#songkick-integration)
 - [Architecture Overview](#architecture-overview)
 - [Configuration & Required Secrets](#configuration--required-secrets)
 - [Local Development](#local-development)
@@ -33,10 +33,10 @@ The Movies tab is a curated discovery feed for film night:
 ### Live Music
 The Live Music tab surfaces concerts near you for the artists you actually play:
 - **One-click Spotify login** that uses PKCE to obtain a user token with `user-top-read` (and optionally `user-read-email`) scopes.
-- **Ticketmaster API key input** with client-side throttling and server-side caching to prevent rate limits.
+- **Songkick API key input** with client-side caching and a server-side rolling cache keyed by location and start date to stay within the daily quota.
 - **Configurable radius and artist limit** stored in local storage so the app remembers your preferences.
 - **Fallback recommendations** – if none of your top artists are touring near you, the tab can show Spotify-generated similar artists based on the same listening history.
-- **Inline status messages** explaining why no shows were found (e.g., no Ticketmaster key, geolocation blocked, Spotify token expired).
+- **Inline status messages** explaining why no shows were found (e.g., no Songkick key, geolocation blocked, Spotify token expired).
 
 ### Recipes
 Cook something new with the Recipes tab:
@@ -64,7 +64,7 @@ The Discover button coordinates multiple APIs and caches to turn your Spotify hi
 
 ### Spotify endpoints in use
 1. **`GET https://api.spotify.com/v1/me/top/artists`** – After login the client requests your top artists (default limit 10, user-adjustable up to 50). This endpoint is scoped by `user-top-read` and reflects listening history across roughly the last 6 months.
-2. **`GET https://api.spotify.com/v1/recommendations`** – When the "Show Spotify recommendations" toggle is on and no local concerts are found, the client requests related artists using your top artist IDs as seeds. Those suggestions are clearly labeled so you can tell when they come from Spotify rather than Ticketmaster.
+2. **`GET https://api.spotify.com/v1/recommendations`** – When the "Show Spotify recommendations" toggle is on and no local concerts are found, the client requests related artists using your top artist IDs as seeds. Those suggestions are clearly labeled so you can tell when they come from Spotify rather than Songkick.
 
 Additional Spotify endpoints already supported by the backend for auth/UI parity:
 - **`GET /api/spotify-client-id`** – a tiny Express endpoint that keeps the client ID out of source control while letting the browser bootstrap the PKCE flow.
@@ -78,20 +78,29 @@ Spotify does not expose a dedicated "liked artists" API, but you can approximate
 If you want Discover to prefer liked artists, you can swap out the Top Artists call in `js/shows.js` for a loop that pages through the saved tracks endpoint (50 items per request) and tallies unique artist IDs. Keep in mind:
 - Saved tracks are capped at 10,000 entries; fetch in batches using the `offset` parameter.
 - The `user-library-read` scope must be added to the login flow when you initialize the Spotify PKCE request.
-- Liked tracks favor individual songs, so you may wish to weigh artists by the number of occurrences before querying Ticketmaster to avoid one-off features dominating the list.
+- Liked tracks favor individual songs, so you may wish to weigh artists by the number of occurrences before querying Songkick to avoid one-off features dominating the list.
 
-### Ticketmaster integration
-For every candidate artist (from top artists or the optional liked-artist aggregation), Discover:
-1. Calls the Express proxy at `/api/ticketmaster` with your Ticketmaster API key. The proxy throttles requests (300 ms minimum spacing) and caches the last 100 artist queries for 15 minutes.
-2. Filters events by the configured radius around your geolocation or saved city.
-3. Sorts results by distance and de-duplicates multi-venue series before rendering cards with ticket links.
+### Songkick integration
+The Songkick proxy performs a location-first search and the client highlights artists you already play:
+1. Calls the Express proxy at `/api/songkick` with your latitude, longitude, radius, start date (today), and a 14-day lookahead. The proxy converts miles to kilometers, persists a rolling 24-hour cache keyed by location and start date, and accepts either the server-side key or a manually supplied one. The client mirrors that policy by caching responses for the same 24-hour window to avoid burning additional Songkick quota on repeat searches.
+2. Filters the returned events to your configured radius and promotes matches whose performers overlap with your top Spotify artists.
+3. Sorts events by proximity and renders ticket links, badges, and Interested/Not Interested actions in the dashboard.
 
-If no Ticketmaster API key is provided, Discover shows a descriptive error and never transmits the request.
+If no Songkick API key is available, Discover prompts for one and never transmits the request without explicit credentials.
+
+### Alternative live music APIs
+If you want a broader "what's happening near me" search without providing artist keywords, consider wiring an additional proxy
+to one of these location-first providers:
+
+- **SeatGeek Discovery API** – `https://api.seatgeek.com/2/events` accepts `lat`, `lon`, and `range` (miles) parameters so you can request all concerts within a radius. Scope results by `type=concert` and cache responses per rounded coordinate bucket to avoid burning through rate limits.
+- **Bandsintown Events API** – `https://rest.bandsintown.com/v4/events` lets you search by `location=LAT,LON` and `radius`. It requires a public app ID and the responses already include venue coordinates, which simplifies distance sorting client-side.
+
+Each provider has distinct authentication and rate limits, so mirror the existing Songkick proxy pattern: store keys server-side, normalize fields to the UI's expected shape (e.g., name, venue, datetime, ticket URL, distance), and short-circuit when no credentials are configured.
 
 ## Architecture Overview
 - **Front end** – A hand-rolled SPA in vanilla JS, HTML, and CSS. Each tab has a dedicated module under `js/` that owns its DOM bindings, local storage, and network calls.
 - **Auth & persistence** – Firebase Auth (Google provider) and Firestore handle user login state plus long-term storage for movies, tab descriptions, and other preferences. Firestore is initialized with persistent caching so the UI stays responsive offline.
-- **Server** – `backend/server.js` is an Express app that serves the static bundle, proxies external APIs (Ticketmaster, Yelp, Spoonacular), and exposes helper routes for descriptions, saved movies, Plaid item creation, etc. It also normalizes responses and caches expensive calls to protect third-party rate limits.
+- **Server** – `backend/server.js` is an Express app that serves the static bundle, proxies external APIs (Songkick, Yelp, Spoonacular), and exposes helper routes for descriptions, saved movies, Plaid item creation, etc. It also normalizes responses and caches expensive calls to protect third-party rate limits.
 - **Cloud Functions** – The `functions/` directory mirrors much of the server logic for deployments that rely on Firebase Functions instead of the local Express instance.
 - **Shared utilities** – Reusable helpers live under `shared/` (e.g., caching primitives, recipe normalization) so both the server and Cloud Functions share a single implementation.
 - **Node scripts** – `scripts/` contains operational tooling for geodata imports, monitoring, and static asset generation. They rely on environment variables documented below.
@@ -104,7 +113,7 @@ Create a `.env` in the project root (and optionally `backend/.env`) with the cre
 | `PORT` | Express server | Override the default `3003` port. |
 | `HOST` | Express server | Bind address; defaults to `0.0.0.0`. |
 | `SPOTIFY_CLIENT_ID` | `/api/spotify-client-id` | PKCE client ID for Spotify login. |
-| `TICKETMASTER_CONSUMER_KEY` | Ticketmaster proxy | Ticketmaster Discovery API key. |
+| `SONGKICK_API_KEY` | Songkick proxy | Songkick Events API key. |
 | `SPOONACULAR_KEY` | Spoonacular proxy | API key for recipe search. |
 | `YELP_API_KEY` | Restaurants proxy | Yelp Fusion API key if you do not pass one per request. |
 | `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV` | Plaid endpoints | Enable financial account linking workflows. |
@@ -123,7 +132,7 @@ Remember to also configure Firebase (see `firebase.json` and `.firebaserc`) if y
    npm start
    ```
    This launches the Express server on `http://localhost:3003` and serves `index.html` plus the API proxies.
-3. **Set up API keys** – Supply environment variables or enter keys in the UI (e.g., TMDB, Ticketmaster). For Spotify you must configure `SPOTIFY_CLIENT_ID` before attempting to log in.
+3. **Set up API keys** – Supply environment variables or enter keys in the UI (e.g., TMDB, Songkick). For Spotify you must configure `SPOTIFY_CLIENT_ID` before attempting to log in.
 4. **Optional Firebase emulators** – If you prefer not to use the production Firestore project during development, configure the Firebase emulator suite and point the app to it.
 
 ## Testing
@@ -132,7 +141,7 @@ Remember to also configure Firebase (see `firebase.json` and `.firebaserc`) if y
 
 ## Troubleshooting Checklist
 - **Spotify login issues** – confirm the redirect URI configured in your Spotify developer dashboard matches the origin and that you requested the correct scopes (`user-top-read` plus `user-library-read` if you enable liked-artist mode).
-- **Empty Discover results** – verify your Ticketmaster key is present and that the search radius encompasses nearby venues; the UI will also display the last error returned by the Ticketmaster API.
+- **Empty Discover results** – verify your Songkick key is present and that the search radius encompasses nearby venues; the UI will also display the last error returned by the Songkick API.
 - **Spoonacular quota errors** – the proxy caches responses for six hours; if you keep seeing rate-limit messages clear the cache collection in Firestore or wait for the TTL to expire.
 - **Firestore permission denials** – authenticate with Google using the Sign In button; most persistence features require a logged-in user.
 - **Yelp proxy failures** – ensure the `x-api-key` header or `YELP_API_KEY` env var is set. The API returns `missing yelp api key` if not.

--- a/index.html
+++ b/index.html
@@ -143,9 +143,9 @@
             <h2>Live Music</h2>
             <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
           </div>
-          <div id="ticketmasterForm" style="margin-bottom:1rem;">
-            <input type="password" id="ticketmasterApiKey" placeholder="Ticketmaster API Key" style="margin-right:.5rem;">
-            <button type="button" id="ticketmasterDiscoverBtn" class="shows-discover-btn">Discover</button>
+          <div id="songkickForm" style="margin-bottom:1rem;">
+            <input type="password" id="songkickApiKey" placeholder="Songkick API Key" style="margin-right:.5rem;">
+            <button type="button" id="songkickDiscoverBtn" class="shows-discover-btn">Discover</button>
           </div>
           <div id="showsConfigControls" class="shows-config">
             <div class="shows-config__field">
@@ -166,10 +166,10 @@
             <button type="button" class="movie-tab shows-tab" data-target="showsInterestedSection">Your Live Music Events</button>
           </div>
           <div id="showsFeedSection">
-            <div id="ticketmasterList" class="decision-container"></div>
+            <div id="songkickList" class="decision-container"></div>
           </div>
           <div id="showsInterestedSection" style="display:none;">
-            <div id="ticketmasterInterestedList" class="decision-container"></div>
+            <div id="songkickInterestedList" class="decision-container"></div>
           </div>
           <div class="shows-spotify-footer">
             <span id="spotifyStatus" class="shows-status"></span>

--- a/js/shows.js
+++ b/js/shows.js
@@ -323,101 +323,163 @@ async function fetchSpotifySuggestions(token, artists) {
   return [];
 }
 
-const TICKETMASTER_CACHE_STORAGE_KEY = 'ticketmasterCacheV1';
-const TICKETMASTER_CACHE_TTL = 1000 * 60 * 30; // 30 minutes
-const MAX_TICKETMASTER_CACHE_ENTRIES = 50;
+const SONGKICK_CACHE_STORAGE_KEY = 'songkickCacheV1';
+const SONGKICK_CACHE_TTL = 1000 * 60 * 60 * 24; // 24 hours
+const MAX_SONGKICK_CACHE_ENTRIES = 50;
 
-function normalizeTicketmasterCacheKey(keyword) {
-  return (keyword || '').toLowerCase().trim();
-}
-
-function loadTicketmasterCache() {
+function loadSongkickCache() {
   if (typeof localStorage === 'undefined') return {};
   try {
-    const raw = localStorage.getItem(TICKETMASTER_CACHE_STORAGE_KEY);
+    const raw = localStorage.getItem(SONGKICK_CACHE_STORAGE_KEY);
     if (!raw) return {};
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === 'object' ? parsed : {};
   } catch (err) {
-    console.warn('Unable to load Ticketmaster cache', err);
+    console.warn('Unable to load Songkick cache', err);
     return {};
   }
 }
 
-function saveTicketmasterCache(cache) {
+function saveSongkickCache(cache) {
   if (typeof localStorage === 'undefined') return;
   try {
-    localStorage.setItem(TICKETMASTER_CACHE_STORAGE_KEY, JSON.stringify(cache));
+    localStorage.setItem(SONGKICK_CACHE_STORAGE_KEY, JSON.stringify(cache));
   } catch (err) {
-    console.warn('Unable to persist Ticketmaster cache', err);
+    console.warn('Unable to persist Songkick cache', err);
   }
 }
 
-const ticketmasterCache = loadTicketmasterCache();
-const ticketmasterMemoryCache = new Map();
+const songkickCache = loadSongkickCache();
+const songkickMemoryCache = new Map();
+const SONGKICK_LOOKAHEAD_DAYS = 14;
 
-function ticketmasterCacheKey(keyword, scope = 'server') {
-  const normalized = normalizeTicketmasterCacheKey(keyword);
-  return normalized ? `${scope}:${normalized}` : '';
+function formatDateForSongkick(date = new Date()) {
+  try {
+    return date.toISOString().slice(0, 10);
+  } catch (err) {
+    console.warn('Unable to format Songkick start date', err);
+    return new Date().toISOString().slice(0, 10);
+  }
 }
 
-function getCachedTicketmasterResponse(keyword, scope = 'server') {
-  const key = ticketmasterCacheKey(keyword, scope);
-  if (!key) return null;
+function songkickCacheKey({ latitude, longitude, radiusMiles, startDate, days, scope = 'server' }) {
+  const lat = Number.isFinite(latitude) ? latitude.toFixed(3) : 'na';
+  const lon = Number.isFinite(longitude) ? longitude.toFixed(3) : 'na';
+  const radius = Number.isFinite(radiusMiles) ? radiusMiles.toFixed(1) : 'na';
+  const normalizedDate = typeof startDate === 'string' ? startDate : 'today';
+  const normalizedDays = Number.isFinite(days) ? Math.round(days) : 14;
+  return `${scope}:${lat}:${lon}:${radius}:${normalizedDate}:${normalizedDays}`;
+}
 
+function getCachedSongkickResponse(params) {
+  const key = songkickCacheKey(params);
   const now = Date.now();
-  const memoryEntry = ticketmasterMemoryCache.get(key);
-  if (memoryEntry && now - memoryEntry.timestamp < TICKETMASTER_CACHE_TTL) {
+  const memoryEntry = songkickMemoryCache.get(key);
+  if (memoryEntry && now - memoryEntry.timestamp < SONGKICK_CACHE_TTL) {
     return memoryEntry.data;
   }
-
-  const storedEntry = ticketmasterCache[key];
-  if (storedEntry && now - storedEntry.timestamp < TICKETMASTER_CACHE_TTL) {
-    ticketmasterMemoryCache.set(key, storedEntry);
+  const storedEntry = songkickCache[key];
+  if (storedEntry && now - storedEntry.timestamp < SONGKICK_CACHE_TTL) {
+    songkickMemoryCache.set(key, storedEntry);
     return storedEntry.data;
   }
-
   return null;
 }
 
-function setCachedTicketmasterResponse(keyword, data, scope = 'server') {
-  const key = ticketmasterCacheKey(keyword, scope);
-  if (!key) return;
+function setCachedSongkickResponse(params, data) {
+  const key = songkickCacheKey(params);
   const entry = { timestamp: Date.now(), data };
-  ticketmasterMemoryCache.set(key, entry);
+  songkickMemoryCache.set(key, entry);
   if (typeof localStorage === 'undefined') return;
-  ticketmasterCache[key] = entry;
+  songkickCache[key] = entry;
 
-  const keys = Object.keys(ticketmasterCache);
+  const keys = Object.keys(songkickCache);
   const now = Date.now();
   for (const existingKey of keys) {
-    if (now - ticketmasterCache[existingKey].timestamp >= TICKETMASTER_CACHE_TTL) {
-      delete ticketmasterCache[existingKey];
+    if (now - songkickCache[existingKey].timestamp >= SONGKICK_CACHE_TTL) {
+      delete songkickCache[existingKey];
     }
   }
 
-  const remainingKeys = Object.keys(ticketmasterCache);
-  if (remainingKeys.length > MAX_TICKETMASTER_CACHE_ENTRIES) {
+  const remainingKeys = Object.keys(songkickCache);
+  if (remainingKeys.length > MAX_SONGKICK_CACHE_ENTRIES) {
     remainingKeys
-      .sort((a, b) => ticketmasterCache[a].timestamp - ticketmasterCache[b].timestamp)
-      .slice(0, remainingKeys.length - MAX_TICKETMASTER_CACHE_ENTRIES)
-      .forEach((oldKey) => {
-        delete ticketmasterCache[oldKey];
+      .sort((a, b) => songkickCache[a].timestamp - songkickCache[b].timestamp)
+      .slice(0, remainingKeys.length - MAX_SONGKICK_CACHE_ENTRIES)
+      .forEach(oldKey => {
+        delete songkickCache[oldKey];
       });
   }
 
-  saveTicketmasterCache(ticketmasterCache);
+  saveSongkickCache(songkickCache);
 }
 
-function getStaleTicketmasterResponse(keyword, scope = 'server') {
-  const key = ticketmasterCacheKey(keyword, scope);
-  if (!key) return null;
-  const memoryEntry = ticketmasterMemoryCache.get(key);
-  if (memoryEntry) {
-    return memoryEntry.data;
+function getSongkickMatchedArtists(event, artistNames) {
+  if (!event || !artistNames?.size) return [];
+  const performances = Array.isArray(event.performance) ? event.performance : [];
+  const matches = new Set();
+  for (const perf of performances) {
+    const name =
+      (perf.artist?.displayName || perf.displayName || perf.name || '').toLowerCase().trim();
+    if (name && artistNames.has(name)) {
+      matches.add(perf.artist?.displayName || perf.displayName || perf.name || '');
+    }
   }
-  const storedEntry = ticketmasterCache[key];
-  return storedEntry?.data || null;
+  return Array.from(matches).filter(Boolean);
+}
+
+function normalizeSongkickEvent(rawEvent, {
+  userLatitude,
+  userLongitude,
+  radiusMiles,
+  order
+}) {
+  if (!rawEvent) return null;
+  const lat = Number.parseFloat(
+    rawEvent.location?.lat ?? rawEvent.venue?.lat ?? rawEvent.venue?.latitude
+  );
+  const lon = Number.parseFloat(
+    rawEvent.location?.lng ?? rawEvent.location?.lon ?? rawEvent.venue?.lng ?? rawEvent.venue?.longitude
+  );
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return null;
+  }
+
+  let distance = null;
+  if (Number.isFinite(userLatitude) && Number.isFinite(userLongitude)) {
+    distance = calculateDistanceMiles(userLatitude, userLongitude, lat, lon);
+  }
+  if (Number.isFinite(distance) && Number.isFinite(radiusMiles) && distance > radiusMiles) {
+    return null;
+  }
+
+  const localDate = rawEvent.start?.date || '';
+  const localTime = rawEvent.start?.time || '';
+  const venueCity = rawEvent.venue?.metroArea?.displayName || rawEvent.location?.city || '';
+  const venueState = rawEvent.venue?.metroArea?.state?.displayName || '';
+
+  const normalized = {
+    id: String(
+      rawEvent.id ||
+        rawEvent.uri ||
+        `${rawEvent.displayName || rawEvent.type || 'event'}-${order}`
+    ),
+    event: {
+      name: rawEvent.displayName || rawEvent.type || 'Live music event',
+      dates: { start: { localDate, localTime } },
+      url: rawEvent.uri || '',
+      images: []
+    },
+    venue: {
+      name: rawEvent.venue?.displayName || '',
+      city: { name: venueCity || '' },
+      state: { stateCode: venueState || '' }
+    },
+    distance: Number.isFinite(distance) ? distance : null,
+    order
+  };
+
+  return normalized;
 }
 
 function toRadians(deg) {
@@ -551,8 +613,8 @@ function getShowStatus(id) {
 }
 
 function renderShowsList() {
-  const listEl = document.getElementById('ticketmasterList');
-  const interestedEl = document.getElementById('ticketmasterInterestedList');
+  const listEl = document.getElementById('songkickList');
+  const interestedEl = document.getElementById('songkickInterestedList');
   if (!listEl && !interestedEl) return;
 
   if (listEl) {
@@ -803,6 +865,19 @@ function createShowCard(item) {
     meta.appendChild(distanceDiv);
   }
 
+  if (Array.isArray(item.matchedArtists) && item.matchedArtists.length) {
+    const matchDiv = document.createElement('div');
+    matchDiv.className = 'show-card__tag show-card__tag--match';
+    const previewArtists = item.matchedArtists.slice(0, 2);
+    let label = previewArtists.join(', ');
+    const remaining = item.matchedArtists.length - previewArtists.length;
+    if (remaining > 0) {
+      label += ` +${remaining} more`;
+    }
+    matchDiv.textContent = `Matches your Spotify: ${label}`;
+    meta.appendChild(matchDiv);
+  }
+
   if (meta.childElementCount > 0) {
     header.appendChild(meta);
   }
@@ -897,14 +972,14 @@ if (typeof window !== 'undefined') {
 }
 
 export async function initShowsPanel() {
-  const listEl = document.getElementById('ticketmasterList');
+  const listEl = document.getElementById('songkickList');
   if (!listEl) return;
-  const interestedListEl = document.getElementById('ticketmasterInterestedList');
+  const interestedListEl = document.getElementById('songkickInterestedList');
   const tokenBtn = document.getElementById('spotifyTokenBtn');
   const statusEl = document.getElementById('spotifyStatus');
-  const apiKeyInput = document.getElementById('ticketmasterApiKey');
+  const apiKeyInput = document.getElementById('songkickApiKey');
   const tabsContainer = document.getElementById('showsTabs');
-  const discoverBtn = document.getElementById('ticketmasterDiscoverBtn');
+  const discoverBtn = document.getElementById('songkickDiscoverBtn');
   const radiusInput = document.getElementById('showsRadius');
   const artistLimitInput = document.getElementById('showsArtistLimit');
   const includeSuggestionsInput = document.getElementById('showsIncludeSuggestions');
@@ -989,13 +1064,13 @@ export async function initShowsPanel() {
   }
 
   let spotifyClientId = '';
-  let serverHasTicketmasterKey = false;
+  let serverHasSongkickKey = false;
   try {
     const res = await fetch(`${API_BASE_URL}/api/spotify-client-id`);
     if (res.ok) {
       const data = await res.json();
       spotifyClientId = data.clientId || '';
-      serverHasTicketmasterKey = Boolean(data.hasTicketmasterKey);
+      serverHasSongkickKey = Boolean(data.hasSongkickKey);
     }
   } catch (err) {
     console.error('Failed to fetch Spotify client ID', err);
@@ -1013,7 +1088,7 @@ export async function initShowsPanel() {
     }
   }
 
-  if (serverHasTicketmasterKey && apiKeyInput) {
+  if (serverHasSongkickKey && apiKeyInput) {
     apiKeyInput.style.display = 'none';
   }
 
@@ -1116,8 +1191,8 @@ export async function initShowsPanel() {
       (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
     const manualApiKey =
       apiKeyInput?.value.trim() ||
-      (typeof localStorage !== 'undefined' && localStorage.getItem('ticketmasterApiKey')) || '';
-    const requiresManualApiKey = !serverHasTicketmasterKey;
+      (typeof localStorage !== 'undefined' && localStorage.getItem('songkickApiKey')) || '';
+    const requiresManualApiKey = !serverHasSongkickKey;
 
     if (!token) {
       currentShows = [];
@@ -1138,15 +1213,15 @@ export async function initShowsPanel() {
     if (requiresManualApiKey && !manualApiKey) {
       currentShows = [];
       currentSuggestions = [];
-      listEl.textContent = 'Please enter your Ticketmaster API key.';
+      listEl.textContent = 'Please enter your Songkick API key.';
       stopLoading();
       return;
     }
 
     if (requiresManualApiKey && apiKeyInput?.value && typeof localStorage !== 'undefined') {
-      localStorage.setItem('ticketmasterApiKey', manualApiKey);
+      localStorage.setItem('songkickApiKey', manualApiKey);
     } else if (!requiresManualApiKey && typeof localStorage !== 'undefined') {
-      localStorage.removeItem('ticketmasterApiKey');
+      localStorage.removeItem('songkickApiKey');
     }
 
     listEl.innerHTML = '<em>Loading...</em>';
@@ -1198,92 +1273,95 @@ export async function initShowsPanel() {
         return;
       }
 
-      const eventsMap = new Map();
-      let eventCounter = 0;
       const apiBase =
         API_BASE_URL && API_BASE_URL !== 'null'
           ? API_BASE_URL.replace(/\/$/, '')
           : '';
-      for (const artist of artists) {
-        const params = new URLSearchParams({ keyword: artist.name });
+      const cacheScope = requiresManualApiKey ? 'manual' : 'server';
+      const startDate = formatDateForSongkick();
+      const cacheParams = {
+        latitude: userLocation.latitude,
+        longitude: userLocation.longitude,
+        radiusMiles,
+        startDate,
+        days: SONGKICK_LOOKAHEAD_DAYS,
+        scope: cacheScope
+      };
+
+      let songkickData = getCachedSongkickResponse(cacheParams);
+      if (!songkickData) {
+        const params = new URLSearchParams({
+          lat: String(userLocation.latitude),
+          lon: String(userLocation.longitude),
+          startDate,
+          days: String(SONGKICK_LOOKAHEAD_DAYS)
+        });
+        if (Number.isFinite(radiusMiles)) {
+          params.set('radius', String(radiusMiles));
+        }
         if (requiresManualApiKey) {
           params.set('apiKey', manualApiKey);
         }
-        const tmUrl = `${apiBase}/api/ticketmaster?${params.toString()}`;
-        const cacheScope = requiresManualApiKey ? 'manual' : 'server';
-        let data = getCachedTicketmasterResponse(artist.name, cacheScope);
-        if (!data) {
-          const res = await fetch(tmUrl);
-          if (!res.ok) {
-            if (res.status === 429) {
-              console.warn('Ticketmaster rate limit reached for', artist.name);
-              data = getStaleTicketmasterResponse(artist.name, cacheScope);
-              if (!data) {
-                continue;
-              }
-            } else {
-              continue;
-            }
-          }
-          if (!data) {
-            data = await res.json();
-            setCachedTicketmasterResponse(artist.name, data, cacheScope);
-          }
+        const skUrl = `${apiBase}/api/songkick?${params.toString()}`;
+        const res = await fetch(skUrl);
+        if (!res.ok) {
+          const errText = await res.text().catch(() => '');
+          throw new Error(
+            `Songkick HTTP ${res.status}${errText ? `: ${errText.slice(0, 200)}` : ''}`
+          );
         }
-        const events = data._embedded?.events;
-        if (!Array.isArray(events)) continue;
-        for (const ev of events) {
-          const venue = ev._embedded?.venues?.[0];
-          const lat = Number.parseFloat(venue?.location?.latitude);
-          const lon = Number.parseFloat(venue?.location?.longitude);
-          let distance = null;
-          if (
-            userLocation &&
-            Number.isFinite(lat) &&
-            Number.isFinite(lon)
-          ) {
-            distance = calculateDistanceMiles(
-              userLocation.latitude,
-              userLocation.longitude,
-              lat,
-              lon
-            );
-          }
-          if (Number.isFinite(distance) && distance > radiusMiles) {
-            continue;
-          }
-          if (distance == null) {
-            continue;
-          }
-          const eventKey =
-            ev.id ||
-            `${artist.id || artist.name || 'artist'}-${ev.url || ev.name || eventCounter}`;
-          if (!eventsMap.has(eventKey)) {
-            eventsMap.set(eventKey, {
-              id: eventKey,
-              event: ev,
-              venue,
-              distance,
-              order: eventCounter++
-            });
-          }
+        songkickData = await res.json();
+        setCachedSongkickResponse(cacheParams, songkickData);
+      }
+
+      const rawEvents = Array.isArray(songkickData?.resultsPage?.results?.event)
+        ? songkickData.resultsPage.results.event
+        : [];
+
+      const artistNames = new Set(
+        artists
+          .map(artist => (artist?.name || '').toLowerCase().trim())
+          .filter(name => Boolean(name))
+      );
+
+      const matchingEvents = [];
+      const otherEvents = [];
+      let eventCounter = 0;
+
+      for (const rawEvent of rawEvents) {
+        const normalized = normalizeSongkickEvent(rawEvent, {
+          userLatitude: userLocation.latitude,
+          userLongitude: userLocation.longitude,
+          radiusMiles,
+          order: eventCounter
+        });
+        if (!normalized) {
+          continue;
+        }
+        normalized.order = eventCounter++;
+        const matchedArtists = getSongkickMatchedArtists(rawEvent, artistNames);
+        if (matchedArtists.length) {
+          normalized.matchedArtists = matchedArtists;
+          matchingEvents.push(normalized);
+        } else {
+          otherEvents.push(normalized);
         }
       }
 
-      if (eventsMap.size > 0) {
-        const events = Array.from(eventsMap.values());
-        if (cachedUserLocation) {
-          events.sort((a, b) => {
-            const aDist = a.distance;
-            const bDist = b.distance;
-            if (aDist == null && bDist == null) return a.order - b.order;
-            if (aDist == null) return 1;
-            if (bDist == null) return -1;
-            if (aDist === bDist) return a.order - b.order;
-            return aDist - bDist;
-          });
-        }
-        currentShows = events;
+      const sortByDistance = (a, b) => {
+        const aDist = Number.isFinite(a.distance) ? a.distance : Infinity;
+        const bDist = Number.isFinite(b.distance) ? b.distance : Infinity;
+        if (aDist === bDist) return a.order - b.order;
+        return aDist - bDist;
+      };
+
+      matchingEvents.sort(sortByDistance);
+      otherEvents.sort(sortByDistance);
+
+      const combinedEvents = matchingEvents.concat(otherEvents);
+
+      if (combinedEvents.length > 0) {
+        currentShows = combinedEvents;
         currentSuggestions = [];
         showsEmptyReason = null;
         renderShowsList();

--- a/style.css
+++ b/style.css
@@ -567,7 +567,7 @@ button:hover {
   position: relative;
 }
 
-#ticketmasterList {
+#songkickList {
   width: 100%;
 }
 
@@ -761,6 +761,11 @@ button:hover {
   padding: 0.2rem 0.75rem;
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+.show-card__tag--match {
+  background: #fdeacc;
+  color: #7a3b00;
 }
 
 .show-card__location {


### PR DESCRIPTION
## Summary
- extend the client-side Songkick cache TTL to 24 hours so repeated fetches reuse daily results
- document the shared 24-hour caching policy in the Songkick integration guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e53a739ac883279086e11c23fd0fe1