### PR TITLE
Sort restaurants by distance and remove radius filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,31 +210,6 @@
           aria-label="Map showing nearby restaurant locations"
         ></div>
         <div id="restaurantsResults" class="restaurants-list decision-container" aria-live="polite">
-          <form id="restaurantsFilters" class="restaurants-filters" aria-labelledby="restaurantsFiltersLegend">
-            <fieldset>
-              <legend id="restaurantsFiltersLegend">Filter restaurants</legend>
-              <label class="restaurants-filters__label" for="restaurantsDistanceSelect">Within</label>
-              <select id="restaurantsDistanceSelect" class="restaurants-filters__control">
-                <option value="1">1 mile</option>
-                <option value="2">2 miles</option>
-                <option value="3">3 miles</option>
-                <option value="4">4 miles</option>
-                <option value="5">5 miles</option>
-                <option value="6">6 miles</option>
-                <option value="7">7 miles</option>
-                <option value="8">8 miles</option>
-                <option value="9">9 miles</option>
-                <option value="10">10 miles</option>
-                <option value="15">15 miles</option>
-                <option value="20">20 miles</option>
-                <option value="25" selected>25 miles</option>
-                <option value="35">35 miles</option>
-                <option value="50">50 miles</option>
-                <option value="75">75 miles</option>
-                <option value="100">100 miles</option>
-              </select>
-            </fieldset>
-          </form>
           <div class="restaurants-tabs" role="tablist" aria-label="Restaurant lists">
             <button
               type="button"

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -7,30 +7,6 @@ function setupDom() {
       <div id="restaurantsPanel">
       <div id="restaurantsMap"></div>
       <div id="restaurantsResults">
-        <form id="restaurantsFilters">
-          <fieldset>
-            <label for="restaurantsDistanceSelect">Within</label>
-            <select id="restaurantsDistanceSelect">
-              <option value="1">1 mile</option>
-              <option value="2">2 miles</option>
-              <option value="3">3 miles</option>
-              <option value="4">4 miles</option>
-              <option value="5">5 miles</option>
-              <option value="6">6 miles</option>
-              <option value="7">7 miles</option>
-              <option value="8">8 miles</option>
-              <option value="9">9 miles</option>
-              <option value="10">10 miles</option>
-              <option value="15">15 miles</option>
-              <option value="20">20 miles</option>
-              <option value="25" selected>25 miles</option>
-              <option value="35">35 miles</option>
-              <option value="50">50 miles</option>
-              <option value="75">75 miles</option>
-              <option value="100">100 miles</option>
-            </select>
-          </fieldset>
-        </form>
         <div class="restaurants-tabs" role="tablist">
           <button type="button" class="restaurants-tab is-active" data-view="nearby" aria-selected="true"></button>
           <button type="button" class="restaurants-tab" data-view="saved" aria-selected="false"></button>
@@ -61,7 +37,7 @@ describe('initRestaurantsPanel', () => {
     delete global.navigator;
   });
 
-  it('requests location and renders restaurants sorted by rating', async () => {
+  it('requests location and renders restaurants sorted by distance', async () => {
     const dom = setupDom();
     global.window = dom.window;
     global.document = dom.window.document;
@@ -79,8 +55,9 @@ describe('initRestaurantsPanel', () => {
     global.navigator = window.navigator;
 
     const sampleData = [
-      { name: 'Second Place', rating: 4.1, reviewCount: 120, distance: 1500 },
-      { name: 'Top Rated', rating: 4.8, reviewCount: 45, distance: 1200 }
+      { name: 'Closest Diner', rating: 3.9, reviewCount: 10, distance: 500 },
+      { name: 'Top Rated', rating: 4.8, reviewCount: 45, distance: 1200 },
+      { name: 'Far Favorite', rating: 5.0, reviewCount: 200, distance: 5000 }
     ];
 
     global.fetch = vi
@@ -105,7 +82,7 @@ describe('initRestaurantsPanel', () => {
 
     const results = document.getElementById('restaurantsResults');
     const headings = Array.from(results.querySelectorAll('h3')).map(el => el.textContent);
-    expect(headings[0]).toBe('Top Rated');
+    expect(headings).toEqual(['Closest Diner', 'Top Rated', 'Far Favorite']);
   });
 
   it('shows message when location permission denied', async () => {
@@ -168,7 +145,7 @@ describe('initRestaurantsPanel', () => {
     expect(results.textContent).toContain('failed');
   });
 
-  it('filters out distant restaurants when coordinates are provided', async () => {
+  it('renders all restaurants returned by the API', async () => {
     const dom = setupDom();
     global.window = dom.window;
     global.document = dom.window.document;
@@ -205,100 +182,7 @@ describe('initRestaurantsPanel', () => {
 
     const results = document.getElementById('restaurantsResults');
     const headings = Array.from(results.querySelectorAll('h3')).map(el => el.textContent);
-    expect(headings).toEqual(['Local Favorite']);
-  });
-
-  it('updates nearby restaurants when the distance filter changes', async () => {
-    const dom = setupDom();
-    global.window = dom.window;
-    global.document = dom.window.document;
-    window.localStorage.clear();
-
-    const geoMock = {
-      getCurrentPosition: vi.fn(success => {
-        success({ coords: { latitude: 35.2271, longitude: -80.8431 } });
-      })
-    };
-    Object.defineProperty(window.navigator, 'geolocation', {
-      configurable: true,
-      value: geoMock
-    });
-    global.navigator = window.navigator;
-
-    const sampleData = [
-      { name: 'Nearby Spot', rating: 4.6, reviewCount: 80, distance: 2500 },
-      { name: 'Across Town', rating: 4.3, reviewCount: 60, distance: 75000 }
-    ];
-
-    global.fetch = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ address: { city: 'Charlotte' } })
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(sampleData)
-      });
-
-    await initRestaurantsPanel();
-
-    let headings = Array.from(
-      document.querySelectorAll('#restaurantsNearby h3')
-    ).map(el => el.textContent);
-    expect(headings).toEqual(['Nearby Spot']);
-
-    const distanceSelect = document.getElementById('restaurantsDistanceSelect');
-    distanceSelect.value = '50';
-    distanceSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
-
-    headings = Array.from(
-      document.querySelectorAll('#restaurantsNearby h3')
-    ).map(el => el.textContent);
-    expect(headings).toEqual(['Nearby Spot', 'Across Town']);
-  });
-
-  it('shows an empty state message when no restaurants match the selected distance', async () => {
-    const dom = setupDom();
-    global.window = dom.window;
-    global.document = dom.window.document;
-    window.localStorage.clear();
-
-    const geoMock = {
-      getCurrentPosition: vi.fn(success => {
-        success({ coords: { latitude: 34.0522, longitude: -118.2437 } });
-      })
-    };
-    Object.defineProperty(window.navigator, 'geolocation', {
-      configurable: true,
-      value: geoMock
-    });
-    global.navigator = window.navigator;
-
-    const sampleData = [
-      { name: 'Far Place', rating: 4.5, reviewCount: 90, distance: 10000 },
-      { name: 'Very Far Place', rating: 4.1, reviewCount: 60, distance: 15000 }
-    ];
-
-    global.fetch = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ address: { city: 'Los Angeles' } })
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(sampleData)
-      });
-
-    await initRestaurantsPanel();
-
-    const distanceSelect = document.getElementById('restaurantsDistanceSelect');
-    distanceSelect.value = '1';
-    distanceSelect.dispatchEvent(new window.Event('change', { bubbles: true }));
-
-    const message = document.querySelector('#restaurantsNearby .restaurants-message');
-    expect(message?.textContent).toContain('No restaurants found within 1 mile.');
+    expect(headings).toEqual(['Local Favorite', 'Distant Gem']);
   });
 
   it('allows saving and unsaving restaurants', async () => {


### PR DESCRIPTION
## Summary
- remove the restaurant radius filter UI
- always sort nearby restaurant results by distance instead of rating filters
- adjust restaurant panel tests to reflect distance-based ordering

## Testing
- npm test -- restaurants.test.js
- vitest run


------
https://chatgpt.com/codex/tasks/task_e_68e53ea89b04832781a0bc425b8199b9