### PR TITLE
Add diagnostic status messaging to movie feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
                 </select>
               </div>
             </div>
+            <div id="movieStatus" class="movie-status" aria-live="polite"></div>
             <div id="movieList" class="decision-container"></div>
           </div>
           <div id="savedMoviesSection" style="display:none;">

--- a/style.css
+++ b/style.css
@@ -2655,6 +2655,34 @@ h2 {
   min-width: 6.5rem;
 }
 
+.movie-status {
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  background: #f1f5f9;
+  color: #1e293b;
+  border: 1px solid transparent;
+}
+
+.movie-status--info {
+  border-color: #38bdf8;
+}
+
+.movie-status--success {
+  border-color: #4ade80;
+}
+
+.movie-status--warning {
+  border-color: #facc15;
+}
+
+.movie-status--error {
+  border-color: #f87171;
+  color: #b91c1c;
+  background: #fef2f2;
+}
+
 .movie-rating {
   font-weight: 600;
   margin: 0 0 0.5rem 0;


### PR DESCRIPTION
## Summary
- add a visible movie feed status banner that reports loading progress and issues
- update movie loading logic to track attempts, proxy fallbacks, and filter effects while surfacing detailed status messages
- style the new status banner and extend automated tests to cover the new diagnostics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e53f994a4083278c8baa3730770d23