### PR TITLE
Adjust Yelp restaurant query for distance sorting

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -245,8 +245,7 @@ app.get('/api/restaurants', async (req, res) => {
 
   const params = new URLSearchParams({
     categories: 'restaurants',
-    limit: '20',
-    sort_by: 'rating'
+    limit: '50'
   });
   if (city) {
     params.set('location', String(city));
@@ -255,6 +254,7 @@ app.get('/api/restaurants', async (req, res) => {
     params.delete('location');
     params.set('latitude', String(latitude));
     params.set('longitude', String(longitude));
+    params.set('sort_by', 'distance');
   }
   if (cuisine) {
     params.set('term', String(cuisine));

--- a/functions/index.js
+++ b/functions/index.js
@@ -402,12 +402,12 @@ exports.restaurantsProxy = functions
 
     const params = new URLSearchParams({
       categories: 'restaurants',
-      limit: '20',
-      sort_by: 'rating'
+      limit: '50'
     });
     if (hasCoords) {
       params.set('latitude', String(latitude));
       params.set('longitude', String(longitude));
+      params.set('sort_by', 'distance');
     } else if (city) {
       params.set('location', city);
     }


### PR DESCRIPTION
## Summary
- request a larger set of restaurants from Yelp without forcing rating-based sorting
- update both the Express API and Firebase function proxies to sort by distance when coordinates are available

## Testing
- npm test *(fails: known showsSpotify pagination test due to missing DOM hook)*

------
https://chatgpt.com/codex/tasks/task_e_68e54359cebc8327aa7cab44d021f72b