### PR TITLE
Schedule movie refills after cooldown

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -65,6 +65,7 @@ let activeUserId = null;
 const activeInterestedGenres = new Set();
 let refillInProgress = false;
 let lastRefillAttempt = 0;
+let pendingRefillCooldownTimer = null;
 let feedExhausted = false;
 let watchedSortMode = 'recent';
 let activeInterestedGenre = null;
@@ -1214,7 +1215,17 @@ async function requestAdditionalMovies() {
     updateFeedStatus(`Waiting ${waitSeconds}s before requesting more movies...`, {
       tone: 'info'
     });
+    if (!pendingRefillCooldownTimer) {
+      pendingRefillCooldownTimer = setTimeout(() => {
+        pendingRefillCooldownTimer = null;
+        requestAdditionalMovies();
+      }, waitMs);
+    }
     return;
+  }
+  if (pendingRefillCooldownTimer) {
+    clearTimeout(pendingRefillCooldownTimer);
+    pendingRefillCooldownTimer = null;
   }
   refillInProgress = true;
   lastRefillAttempt = now;


### PR DESCRIPTION
## Summary
- automatically queue a movie feed refill after the cooldown expires instead of requiring another manual trigger
- clear any pending cooldown timer when a new refill attempt begins to avoid duplicate requests

## Testing
- npm test *(fails: TypeError: Cannot read properties of null (reading '_showsClickHandler') in tests/showsSpotify.test.js > initShowsPanel > paginates through Spotify top artists when limit exceeds one page)*

------
https://chatgpt.com/codex/tasks/task_e_68e54408f02483278c2ec99c1b6d9570