### PR TITLE
Switch live music integration to Eventbrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dashboard is a personal decision-making and entertainment hub that brings movie 
 - [How the Live Music Discover Flow Works](#how-the-live-music-discover-flow-works)
   - [Spotify endpoints in use](#spotify-endpoints-in-use)
   - [Using liked songs instead of top artists](#using-liked-songs-instead-of-top-artists)
-  - [Songkick integration](#songkick-integration)
+- [Eventbrite integration](#eventbrite-integration)
 - [Architecture Overview](#architecture-overview)
 - [Configuration & Required Secrets](#configuration--required-secrets)
 - [Local Development](#local-development)
@@ -33,10 +33,10 @@ The Movies tab is a curated discovery feed for film night:
 ### Live Music
 The Live Music tab surfaces concerts near you for the artists you actually play:
 - **One-click Spotify login** that uses PKCE to obtain a user token with `user-top-read` (and optionally `user-read-email`) scopes.
-- **Songkick API key input** with client-side caching and a server-side rolling cache keyed by location and start date to stay within the daily quota.
+- **Eventbrite API token input** with client-side caching and a server-side rolling cache keyed by location and start date to stay within the daily quota.
 - **Configurable radius and artist limit** stored in local storage so the app remembers your preferences.
 - **Fallback recommendations** – if none of your top artists are touring near you, the tab can show Spotify-generated similar artists based on the same listening history.
-- **Inline status messages** explaining why no shows were found (e.g., no Songkick key, geolocation blocked, Spotify token expired).
+- **Inline status messages** explaining why no shows were found (e.g., no Eventbrite token, geolocation blocked, Spotify token expired).
 
 ### Recipes
 Cook something new with the Recipes tab:
@@ -64,7 +64,7 @@ The Discover button coordinates multiple APIs and caches to turn your Spotify hi
 
 ### Spotify endpoints in use
 1. **`GET https://api.spotify.com/v1/me/top/artists`** – After login the client requests your top artists (default limit 10, user-adjustable up to 50). This endpoint is scoped by `user-top-read` and reflects listening history across roughly the last 6 months.
-2. **`GET https://api.spotify.com/v1/recommendations`** – When the "Show Spotify recommendations" toggle is on and no local concerts are found, the client requests related artists using your top artist IDs as seeds. Those suggestions are clearly labeled so you can tell when they come from Spotify rather than Songkick.
+2. **`GET https://api.spotify.com/v1/recommendations`** – When the "Show Spotify recommendations" toggle is on and no local concerts are found, the client requests related artists using your top artist IDs as seeds. Those suggestions are clearly labeled so you can tell when they come from Spotify rather than Eventbrite.
 
 Additional Spotify endpoints already supported by the backend for auth/UI parity:
 - **`GET /api/spotify-client-id`** – a tiny Express endpoint that keeps the client ID out of source control while letting the browser bootstrap the PKCE flow.
@@ -78,15 +78,15 @@ Spotify does not expose a dedicated "liked artists" API, but you can approximate
 If you want Discover to prefer liked artists, you can swap out the Top Artists call in `js/shows.js` for a loop that pages through the saved tracks endpoint (50 items per request) and tallies unique artist IDs. Keep in mind:
 - Saved tracks are capped at 10,000 entries; fetch in batches using the `offset` parameter.
 - The `user-library-read` scope must be added to the login flow when you initialize the Spotify PKCE request.
-- Liked tracks favor individual songs, so you may wish to weigh artists by the number of occurrences before querying Songkick to avoid one-off features dominating the list.
+- Liked tracks favor individual songs, so you may wish to weigh artists by the number of occurrences before querying Eventbrite to avoid one-off features dominating the list.
 
-### Songkick integration
-The Songkick proxy performs a location-first search and the client highlights artists you already play:
-1. Calls the Express proxy at `/api/songkick` with your latitude, longitude, radius, start date (today), and a 14-day lookahead. The proxy converts miles to kilometers, persists a rolling 24-hour cache keyed by location and start date, and accepts either the server-side key or a manually supplied one. The client mirrors that policy by caching responses for the same 24-hour window to avoid burning additional Songkick quota on repeat searches.
+### Eventbrite integration
+The Eventbrite proxy performs a location-first search and the client highlights artists you already play:
+1. Calls the Express proxy at `/api/eventbrite` with your latitude, longitude, radius, start date (today), and a 14-day lookahead. The proxy converts the radius to Eventbrite's `within` parameter, persists a rolling 24-hour cache keyed by location and start date, and accepts either the server-side token or a manually supplied one. The client mirrors that policy by caching responses for the same 24-hour window to avoid burning additional Eventbrite quota on repeat searches.
 2. Filters the returned events to your configured radius and promotes matches whose performers overlap with your top Spotify artists.
 3. Sorts events by proximity and renders ticket links, badges, and Interested/Not Interested actions in the dashboard.
 
-If no Songkick API key is available, Discover prompts for one and never transmits the request without explicit credentials.
+If no Eventbrite API token is available, Discover prompts for one and never transmits the request without explicit credentials.
 
 ### Alternative live music APIs
 If you want a broader "what's happening near me" search without providing artist keywords, consider wiring an additional proxy
@@ -95,12 +95,12 @@ to one of these location-first providers:
 - **SeatGeek Discovery API** – `https://api.seatgeek.com/2/events` accepts `lat`, `lon`, and `range` (miles) parameters so you can request all concerts within a radius. Scope results by `type=concert` and cache responses per rounded coordinate bucket to avoid burning through rate limits.
 - **Bandsintown Events API** – `https://rest.bandsintown.com/v4/events` lets you search by `location=LAT,LON` and `radius`. It requires a public app ID and the responses already include venue coordinates, which simplifies distance sorting client-side.
 
-Each provider has distinct authentication and rate limits, so mirror the existing Songkick proxy pattern: store keys server-side, normalize fields to the UI's expected shape (e.g., name, venue, datetime, ticket URL, distance), and short-circuit when no credentials are configured.
+Each provider has distinct authentication and rate limits, so mirror the existing Eventbrite proxy pattern: store tokens server-side, normalize fields to the UI's expected shape (e.g., name, venue, datetime, ticket URL, distance), and short-circuit when no credentials are configured.
 
 ## Architecture Overview
 - **Front end** – A hand-rolled SPA in vanilla JS, HTML, and CSS. Each tab has a dedicated module under `js/` that owns its DOM bindings, local storage, and network calls.
 - **Auth & persistence** – Firebase Auth (Google provider) and Firestore handle user login state plus long-term storage for movies, tab descriptions, and other preferences. Firestore is initialized with persistent caching so the UI stays responsive offline.
-- **Server** – `backend/server.js` is an Express app that serves the static bundle, proxies external APIs (Songkick, Yelp, Spoonacular), and exposes helper routes for descriptions, saved movies, Plaid item creation, etc. It also normalizes responses and caches expensive calls to protect third-party rate limits.
+- **Server** – `backend/server.js` is an Express app that serves the static bundle, proxies external APIs (Eventbrite, Yelp, Spoonacular), and exposes helper routes for descriptions, saved movies, Plaid item creation, etc. It also normalizes responses and caches expensive calls to protect third-party rate limits.
 - **Cloud Functions** – The `functions/` directory mirrors much of the server logic for deployments that rely on Firebase Functions instead of the local Express instance.
 - **Shared utilities** – Reusable helpers live under `shared/` (e.g., caching primitives, recipe normalization) so both the server and Cloud Functions share a single implementation.
 - **Node scripts** – `scripts/` contains operational tooling for geodata imports, monitoring, and static asset generation. They rely on environment variables documented below.
@@ -113,7 +113,7 @@ Create a `.env` in the project root (and optionally `backend/.env`) with the cre
 | `PORT` | Express server | Override the default `3003` port. |
 | `HOST` | Express server | Bind address; defaults to `0.0.0.0`. |
 | `SPOTIFY_CLIENT_ID` | `/api/spotify-client-id` | PKCE client ID for Spotify login. |
-| `SONGKICK_API_KEY` | Songkick proxy | Songkick Events API key. |
+| `EVENTBRITE_API_TOKEN` or `EVENTBRITE_OAUTH_TOKEN` | Eventbrite proxy | Eventbrite personal token used for the Events Search API. |
 | `SPOONACULAR_KEY` | Spoonacular proxy | API key for recipe search. |
 | `YELP_API_KEY` | Restaurants proxy | Yelp Fusion API key if you do not pass one per request. |
 | `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV` | Plaid endpoints | Enable financial account linking workflows. |
@@ -132,7 +132,7 @@ Remember to also configure Firebase (see `firebase.json` and `.firebaserc`) if y
    npm start
    ```
    This launches the Express server on `http://localhost:3003` and serves `index.html` plus the API proxies.
-3. **Set up API keys** – Supply environment variables or enter keys in the UI (e.g., TMDB, Songkick). For Spotify you must configure `SPOTIFY_CLIENT_ID` before attempting to log in.
+3. **Set up API keys** – Supply environment variables or enter tokens in the UI (e.g., TMDB, Eventbrite). For Spotify you must configure `SPOTIFY_CLIENT_ID` before attempting to log in.
 4. **Optional Firebase emulators** – If you prefer not to use the production Firestore project during development, configure the Firebase emulator suite and point the app to it.
 
 ## Testing
@@ -141,7 +141,7 @@ Remember to also configure Firebase (see `firebase.json` and `.firebaserc`) if y
 
 ## Troubleshooting Checklist
 - **Spotify login issues** – confirm the redirect URI configured in your Spotify developer dashboard matches the origin and that you requested the correct scopes (`user-top-read` plus `user-library-read` if you enable liked-artist mode).
-- **Empty Discover results** – verify your Songkick key is present and that the search radius encompasses nearby venues; the UI will also display the last error returned by the Songkick API.
+- **Empty Discover results** – verify your Eventbrite token is present and that the search radius encompasses nearby venues; the UI will also display the last error returned by the Eventbrite API.
 - **Spoonacular quota errors** – the proxy caches responses for six hours; if you keep seeing rate-limit messages clear the cache collection in Firestore or wait for the TTL to expire.
 - **Firestore permission denials** – authenticate with Google using the Sign In button; most persistence features require a logged-in user.
 - **Yelp proxy failures** – ensure the `x-api-key` header or `YELP_API_KEY` env var is set. The API returns `missing yelp api key` if not.

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,11 +31,12 @@ movieCatalog
   });
 const PORT = Number(process.env.PORT) || 3003;
 const HOST = process.env.HOST || (process.env.VITEST ? '127.0.0.1' : '0.0.0.0');
-const SONGKICK_API_KEY = process.env.SONGKICK_API_KEY || '';
-const HAS_SONGKICK_KEY = Boolean(SONGKICK_API_KEY);
+const EVENTBRITE_API_TOKEN =
+  process.env.EVENTBRITE_API_TOKEN || process.env.EVENTBRITE_OAUTH_TOKEN || '';
+const HAS_EVENTBRITE_TOKEN = Boolean(EVENTBRITE_API_TOKEN);
 const YELP_CACHE_COLLECTION = 'yelpCache';
 const YELP_CACHE_TTL_MS = 1000 * 60 * 30; // 30 minutes
-const SONGKICK_CACHE_COLLECTION = 'songkickCache';
+const EVENTBRITE_CACHE_COLLECTION = 'eventbriteCache';
 const SPOONACULAR_CACHE_COLLECTION = 'recipeCache';
 const SPOONACULAR_CACHE_TTL_MS = 1000 * 60 * 60 * 6; // 6 hours
 const DEFAULT_MOVIE_LIMIT = 20;
@@ -217,9 +218,9 @@ app.post('/api/saved-movies', (req, res) => {
 app.get('/api/spotify-client-id', (req, res) => {
   const clientId = process.env.SPOTIFY_CLIENT_ID;
   if (!clientId) {
-    return res.status(500).json({ error: 'missing' });
+    return res.status(500).json({ error: 'missing', hasEventbriteToken: HAS_EVENTBRITE_TOKEN });
   }
-  res.json({ clientId, hasSongkickKey: HAS_SONGKICK_KEY });
+  res.json({ clientId, hasEventbriteToken: HAS_EVENTBRITE_TOKEN });
 });
 
 app.get('/api/restaurants', async (req, res) => {
@@ -321,11 +322,11 @@ app.get('/api/restaurants', async (req, res) => {
   }
 });
 
-// --- Songkick proxy ---
-const SONGKICK_CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
-const SONGKICK_CACHE_MAX_ENTRIES = 200;
+// --- Eventbrite proxy ---
+const EVENTBRITE_CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
+const EVENTBRITE_CACHE_MAX_ENTRIES = 200;
 
-const songkickCache = new Map();
+const eventbriteCache = new Map();
 
 function normalizeCoordinate(value, digits = 3) {
   const num = Number.parseFloat(value);
@@ -349,21 +350,21 @@ function addDays(dateString, days) {
   return toDateString(date);
 }
 
-function songkickMemoryCacheKey({ scope, latitude, longitude, radiusKm, startDate, endDate }) {
+function eventbriteMemoryCacheKey({ scope, latitude, longitude, radiusMiles, startDate, endDate }) {
   const latPart = normalizeCoordinate(latitude, 3);
   const lonPart = normalizeCoordinate(longitude, 3);
-  const radiusPart = Number.isFinite(radiusKm) ? Number(radiusKm.toFixed(1)) : 'none';
+  const radiusPart = Number.isFinite(radiusMiles) ? Number(radiusMiles.toFixed(1)) : 'none';
   return [scope, latPart, lonPart, radiusPart, startDate, endDate].join('::');
 }
 
-function songkickCacheKeyParts({ apiKey, latitude, longitude, radiusKm, startDate, endDate }) {
-  const keyPart = String(apiKey || '').trim().toLowerCase();
+function eventbriteCacheKeyParts({ token, latitude, longitude, radiusMiles, startDate, endDate }) {
+  const tokenPart = String(token || '');
   const latPart = normalizeCoordinate(latitude, 3);
   const lonPart = normalizeCoordinate(longitude, 3);
-  const radiusPart = Number.isFinite(radiusKm) ? Number(radiusKm.toFixed(1)) : 'none';
+  const radiusPart = Number.isFinite(radiusMiles) ? Number(radiusMiles.toFixed(1)) : 'none';
   return [
-    'songkick',
-    keyPart,
+    'eventbrite',
+    tokenPart,
     `lat:${latPart}`,
     `lon:${lonPart}`,
     `radius:${radiusPart}`,
@@ -372,24 +373,24 @@ function songkickCacheKeyParts({ apiKey, latitude, longitude, radiusKm, startDat
   ];
 }
 
-function getSongkickCacheEntry(key) {
-  const entry = songkickCache.get(key);
+function getEventbriteCacheEntry(key) {
+  const entry = eventbriteCache.get(key);
   if (!entry) return null;
-  if (Date.now() - entry.timestamp > SONGKICK_CACHE_TTL_MS) {
-    songkickCache.delete(key);
+  if (Date.now() - entry.timestamp > EVENTBRITE_CACHE_TTL_MS) {
+    eventbriteCache.delete(key);
     return null;
   }
-  songkickCache.delete(key);
-  songkickCache.set(key, entry);
+  eventbriteCache.delete(key);
+  eventbriteCache.set(key, entry);
   return entry.value;
 }
 
-function setSongkickCacheEntry(key, value) {
-  songkickCache.set(key, { timestamp: Date.now(), value });
-  if (songkickCache.size > SONGKICK_CACHE_MAX_ENTRIES) {
-    const oldestKey = songkickCache.keys().next().value;
+function setEventbriteCacheEntry(key, value) {
+  eventbriteCache.set(key, { timestamp: Date.now(), value });
+  if (eventbriteCache.size > EVENTBRITE_CACHE_MAX_ENTRIES) {
+    const oldestKey = eventbriteCache.keys().next().value;
     if (oldestKey) {
-      songkickCache.delete(oldestKey);
+      eventbriteCache.delete(oldestKey);
     }
   }
 }
@@ -407,56 +408,56 @@ function normalizeDateString(value) {
   return toDateString(date);
 }
 
-app.get('/api/songkick', async (req, res) => {
-  const { apiKey: queryKey, lat, lon, radius, startDate: startParam, days } = req.query || {};
+app.get('/api/eventbrite', async (req, res) => {
+  const { token: queryToken, lat, lon, radius, startDate: startParam, days } = req.query || {};
   const latitude = normalizeCoordinate(lat, 4);
   const longitude = normalizeCoordinate(lon, 4);
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
     return res.status(400).json({ error: 'missing coordinates' });
   }
 
-  const radiusMiles = Number.parseFloat(radius);
-  const radiusKm = Number.isFinite(radiusMiles) && radiusMiles > 0 ? radiusMiles * 1.60934 : null;
+  const radiusMilesRaw = Number.parseFloat(radius);
+  const radiusMiles = Number.isFinite(radiusMilesRaw) && radiusMilesRaw > 0 ? radiusMilesRaw : null;
 
   const today = toDateString(new Date());
   const normalizedStart = normalizeDateString(startParam) || today;
   const lookaheadDays = clampDays(days);
   const endDate = addDays(normalizedStart, lookaheadDays - 1) || normalizedStart;
 
-  const effectiveKey = queryKey || SONGKICK_API_KEY;
-  if (!effectiveKey) {
-    return res.status(500).json({ error: 'missing songkick api key' });
+  const effectiveToken = queryToken || EVENTBRITE_API_TOKEN;
+  if (!effectiveToken) {
+    return res.status(500).json({ error: 'missing eventbrite api token' });
   }
 
-  const scope = queryKey ? 'manual' : 'server';
-  const memoryKey = songkickMemoryCacheKey({
+  const scope = queryToken ? 'manual' : 'server';
+  const memoryKey = eventbriteMemoryCacheKey({
     scope,
     latitude,
     longitude,
-    radiusKm,
+    radiusMiles,
     startDate: normalizedStart,
     endDate
   });
 
-  const cached = getSongkickCacheEntry(memoryKey);
+  const cached = getEventbriteCacheEntry(memoryKey);
   if (cached) {
     return res.status(cached.status).type('application/json').send(cached.text);
   }
 
   const sharedCached = await readCachedResponse(
-    SONGKICK_CACHE_COLLECTION,
-    songkickCacheKeyParts({
-      apiKey: scope === 'manual' ? queryKey : effectiveKey,
+    EVENTBRITE_CACHE_COLLECTION,
+    eventbriteCacheKeyParts({
+      token: scope === 'manual' ? queryToken : effectiveToken,
       latitude,
       longitude,
-      radiusKm,
+      radiusMiles,
       startDate: normalizedStart,
       endDate
     }),
-    SONGKICK_CACHE_TTL_MS
+    EVENTBRITE_CACHE_TTL_MS
   );
   if (sharedCached) {
-    setSongkickCacheEntry(memoryKey, {
+    setEventbriteCacheEntry(memoryKey, {
       status: sharedCached.status,
       text: sharedCached.body
     });
@@ -465,47 +466,59 @@ app.get('/api/songkick', async (req, res) => {
   }
 
   const params = new URLSearchParams({
-    apikey: effectiveKey,
-    location: `geo:${latitude},${longitude}`,
-    per_page: '50',
-    min_date: normalizedStart,
-    max_date: endDate
+    'location.latitude': String(latitude),
+    'location.longitude': String(longitude),
+    expand: 'venue',
+    sort_by: 'date',
+    'start_date.range_start': `${normalizedStart}T00:00:00Z`,
+    'start_date.range_end': `${endDate}T23:59:59Z`
   });
-  if (Number.isFinite(radiusKm)) {
-    params.set('radius', radiusKm.toFixed(1));
+
+  if (Number.isFinite(radiusMiles)) {
+    params.set('location.within', `${Math.min(Math.max(radiusMiles, 1), 1000).toFixed(1)}mi`);
+  } else {
+    params.set('location.within', '100.0mi');
   }
 
-  const url = `https://api.songkick.com/api/3.0/events.json?${params.toString()}`;
+  const url = `https://www.eventbriteapi.com/v3/events/search/?${params.toString()}`;
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${effectiveToken}`
+      }
+    });
     const text = await response.text();
     if (response.ok) {
-      setSongkickCacheEntry(memoryKey, { status: response.status, text });
-      await writeCachedResponse(SONGKICK_CACHE_COLLECTION, songkickCacheKeyParts({
-        apiKey: scope === 'manual' ? queryKey : effectiveKey,
-        latitude,
-        longitude,
-        radiusKm,
-        startDate: normalizedStart,
-        endDate
-      }), {
-        status: response.status,
-        contentType: 'application/json',
-        body: text,
-        metadata: {
+      setEventbriteCacheEntry(memoryKey, { status: response.status, text });
+      await writeCachedResponse(
+        EVENTBRITE_CACHE_COLLECTION,
+        eventbriteCacheKeyParts({
+          token: scope === 'manual' ? queryToken : effectiveToken,
           latitude,
           longitude,
-          radiusMiles: Number.isFinite(radiusMiles) ? radiusMiles : null,
+          radiusMiles,
           startDate: normalizedStart,
-          endDate,
-          usingDefaultKey: !queryKey
+          endDate
+        }),
+        {
+          status: response.status,
+          contentType: 'application/json',
+          body: text,
+          metadata: {
+            latitude,
+            longitude,
+            radiusMiles: Number.isFinite(radiusMiles) ? radiusMiles : null,
+            startDate: normalizedStart,
+            endDate,
+            usingDefaultToken: !queryToken
+          }
         }
-      });
+      );
     }
     res.status(response.status).type('application/json').send(text);
   } catch (err) {
-    console.error('Songkick fetch failed', err);
+    console.error('Eventbrite fetch failed', err);
     res.status(500).json({ error: 'failed' });
   }
 });

--- a/index.html
+++ b/index.html
@@ -143,9 +143,9 @@
             <h2>Live Music</h2>
             <button type="button" class="icon-btn tab-hide-btn" title="Hide Tab">🕒</button>
           </div>
-          <div id="songkickForm" style="margin-bottom:1rem;">
-            <input type="password" id="songkickApiKey" placeholder="Songkick API Key" style="margin-right:.5rem;">
-            <button type="button" id="songkickDiscoverBtn" class="shows-discover-btn">Discover</button>
+          <div id="eventbriteForm" style="margin-bottom:1rem;">
+            <input type="password" id="eventbriteApiToken" placeholder="Eventbrite API token" style="margin-right:.5rem;">
+            <button type="button" id="eventbriteDiscoverBtn" class="shows-discover-btn">Discover</button>
           </div>
           <div id="showsConfigControls" class="shows-config">
             <div class="shows-config__field">
@@ -166,10 +166,10 @@
             <button type="button" class="movie-tab shows-tab" data-target="showsInterestedSection">Your Live Music Events</button>
           </div>
           <div id="showsFeedSection">
-            <div id="songkickList" class="decision-container"></div>
+            <div id="eventbriteList" class="decision-container"></div>
           </div>
           <div id="showsInterestedSection" style="display:none;">
-            <div id="songkickInterestedList" class="decision-container"></div>
+            <div id="eventbriteInterestedList" class="decision-container"></div>
           </div>
           <div class="shows-spotify-footer">
             <span id="spotifyStatus" class="shows-status"></span>

--- a/style.css
+++ b/style.css
@@ -567,7 +567,7 @@ button:hover {
   position: relative;
 }
 
-#songkickList {
+#eventbriteList {
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- replace the Songkick proxy with an Eventbrite-backed implementation that caches by location and token
- update the live music panel to call the new Eventbrite endpoint, normalize events, and store manual tokens
- refresh documentation, markup, styles, and tests to reflect Eventbrite terminology and behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e542b0d964832791c625f4d73797e4