### PR TITLE
Improve TMDB proxy credit parameter fallbacks

### DIFF
--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -686,9 +686,15 @@ describe('initMoviesPanel', () => {
     };
     const genres = { genres: [] };
 
-    global.fetch = vi.fn()
+    global.fetch = vi
+      .fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(page) })
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(empty) })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve(JSON.stringify({ error: 'invalid_endpoint_params' }))
+      })
       .mockResolvedValueOnce({
         ok: false,
         status: 400,
@@ -699,13 +705,16 @@ describe('initMoviesPanel', () => {
 
     await initMoviesPanel();
 
-    expect(global.fetch).toHaveBeenCalledTimes(5);
+    expect(global.fetch).toHaveBeenCalledTimes(6);
     const firstCreditsUrl = String(global.fetch.mock.calls[2][0]);
-    const retryCreditsUrl = String(global.fetch.mock.calls[3][0]);
+    const secondCreditsUrl = String(global.fetch.mock.calls[3][0]);
+    const finalCreditsUrl = String(global.fetch.mock.calls[4][0]);
     expect(firstCreditsUrl).toContain('endpoint=credits');
     expect(firstCreditsUrl).toContain('movie_id=');
-    expect(retryCreditsUrl).toContain('endpoint=credits');
-    expect(retryCreditsUrl).toContain('movieId=');
+    expect(secondCreditsUrl).toContain('endpoint=credits');
+    expect(secondCreditsUrl).toContain('id=');
+    expect(finalCreditsUrl).toContain('endpoint=credits');
+    expect(finalCreditsUrl).toContain('movieId=');
 
     const listContent = document.getElementById('movieList')?.textContent || '';
     expect(listContent).toContain('Proxy Legacy Star');


### PR DESCRIPTION
## Summary
- expand TMDB proxy credit fetching to try movie_id, id, and movieId parameters while marking unsupported endpoints to stop repeated failures
- guard against unsupported proxy responses during retries to fall back to direct fetching more quickly
- update movies panel tests to cover the new retry order and parameter handling

## Testing
- npm test -- movies

------
https://chatgpt.com/codex/tasks/task_e_68e5449c969c8327a08c22c462f93202