### PR TITLE
Clarify movie loading status messages

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -1872,9 +1872,17 @@ async function loadMovies({ attemptStart } = {}) {
   const startedLabel = formatTimestamp(
     Number.isFinite(attemptStart) ? attemptStart : Date.now()
   );
-  const sourceLabel = usingProxy ? 'TMDB proxy' : 'TMDB API';
+  const sourceLabel = usingProxy ? 'TMDB proxy service' : 'direct TMDB API';
+  const attemptIntro = usingProxy
+    ? 'Reaching out to the TMDB proxy service with your saved preferences.'
+    : 'Contacting TMDB directly using your API key.';
+  const fallbackNote = usingProxy
+    ? ' If this route fails we will automatically switch to your TMDB API key.'
+    : '';
   updateFeedStatus(
-    `Attempt ${attemptNumber} started${startedLabel ? ` at ${startedLabel}` : ''} via ${sourceLabel}...`,
+    `Loading movies (attempt ${attemptNumber})${
+      startedLabel ? ` started at ${startedLabel}` : ''
+    }. ${attemptIntro}${fallbackNote}`,
     { tone: 'info' }
   );
 
@@ -1892,16 +1900,20 @@ async function loadMovies({ attemptStart } = {}) {
     const availableCount = getFeedMovies(currentMovies).length;
     const completedLabel = formatTimestamp(Date.now());
     updateFeedStatus(
-      `Attempt ${attemptNumber} completed${completedLabel ? ` at ${completedLabel}` : ''} via ${sourceLabel}: ${
-        movies.length
-      } fetched, ${availableCount} available after filters.`,
+      `Loaded ${movies.length} movie${movies.length === 1 ? '' : 's'} on attempt ${attemptNumber}${
+        completedLabel ? ` at ${completedLabel}` : ''
+      } using the ${sourceLabel}. ${availableCount} ${
+        availableCount === 1 ? 'match' : 'matches'
+      } your current filters.`,
       { tone: availableCount ? 'success' : 'warning' }
     );
   } catch (err) {
     if (usingProxy) {
       console.warn('TMDB proxy unavailable, falling back to direct API', err);
       updateFeedStatus(
-        `Attempt ${attemptNumber} via TMDB proxy failed: ${summarizeProxyError(err)}. Trying direct API...`,
+        `Attempt ${attemptNumber} using the TMDB proxy service failed (${summarizeProxyError(
+          err
+        )}). Switching to your direct TMDB API key.`,
         { tone: 'warning' }
       );
       disableTmdbProxy();
@@ -1920,7 +1932,9 @@ async function loadMovies({ attemptStart } = {}) {
     console.error('Failed to load movies', err);
     listEl.textContent = 'Failed to load movies.';
     updateFeedStatus(
-      `Attempt ${attemptNumber} via ${sourceLabel} failed: ${summarizeError(err)}.`,
+      `Attempt ${attemptNumber} using the ${sourceLabel} failed (${summarizeError(
+        err
+      )}). No movies were loaded. Check your TMDB API key and try again.`,
       { tone: 'error' }
     );
   }

--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -171,7 +171,8 @@ describe('initMoviesPanel', () => {
     expect(img?.src).toContain('https://image.tmdb.org/t/p/w200/poster.jpg');
 
     const statusText = document.getElementById('movieStatus')?.textContent || '';
-    expect(statusText).toContain('1 fetched, 1 available after filters');
+    expect(statusText).toContain('Loaded 1 movie on attempt 1');
+    expect(statusText).toContain('1 match your current filters');
   });
 
   it('provides guidance when TMDB API key is missing', async () => {
@@ -216,7 +217,9 @@ describe('initMoviesPanel', () => {
     await initMoviesPanel();
 
     const statusText = document.getElementById('movieStatus')?.textContent || '';
-    expect(statusText).toBe('Attempt 1 via TMDB API failed: Failed to fetch movies.');
+    expect(statusText).toBe(
+      'Attempt 1 using the direct TMDB API failed (Failed to fetch movies). No movies were loaded. Check your TMDB API key and try again.'
+    );
   });
 
   it('filters out movies below rating or vote thresholds', async () => {


### PR DESCRIPTION
## Summary
- explain movie loading attempts with clearer status text, including fallback guidance
- update unit tests to assert the new status messaging

## Testing
- `npm test` *(fails: tests/showsSpotify.test.js > initShowsPanel > paginates through Spotify top artists when limit exceeds one page)*

------
https://chatgpt.com/codex/tasks/task_e_68e545a75a308327ab219c7b2715f718