### PR TITLE
Fix hidden restaurants collapse styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -3116,6 +3116,10 @@ h2 {
   gap: 0.65rem;
 }
 
+.restaurants-hidden-list[hidden] {
+  display: none;
+}
+
 .restaurants-hidden-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- ensure the hidden restaurants list respects the collapsed state by overriding its display when the hidden attribute is set

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e54897044083278cae7f3c9abc64bb