### PR TITLE
Cache TMDB catalog by release range

### DIFF
--- a/backend/movie-catalog.js
+++ b/backend/movie-catalog.js
@@ -6,6 +6,45 @@ const MIN_SCORE = 6;
 const DEFAULT_LIMIT = 20;
 const MOVIE_CACHE_COLLECTION = 'movieCatalog';
 const MOVIE_CACHE_KEY = ['curated', 'v1'];
+const MOVIE_RANGE_CACHE_COLLECTION = 'movieCatalogRanges';
+const MOVIE_RANGE_CACHE_VERSION = 'v1';
+const MOVIE_RANGE_SPAN_YEARS = Math.max(
+  1,
+  Number(process.env.MOVIE_CATALOG_RANGE_SPAN_YEARS) || 5
+);
+const MOVIE_RANGE_MIN_YEAR = (() => {
+  const configured = Number(process.env.MOVIE_CATALOG_MIN_YEAR);
+  if (Number.isFinite(configured)) {
+    return Math.max(1900, Math.floor(configured));
+  }
+  return 1970;
+})();
+const MOVIE_RANGE_MAX_YEAR = (() => {
+  const currentYear = new Date().getFullYear();
+  const configured = Number(process.env.MOVIE_CATALOG_MAX_YEAR);
+  if (Number.isFinite(configured)) {
+    return Math.max(MOVIE_RANGE_MIN_YEAR, Math.floor(configured));
+  }
+  return Math.max(MOVIE_RANGE_MIN_YEAR, currentYear);
+})();
+const MOVIE_RANGE_CACHE_TTL_MS = Math.max(
+  24 * 60 * 60 * 1000,
+  Number(process.env.MOVIE_CATALOG_RANGE_TTL_MS) || 90 * 24 * 60 * 60 * 1000
+);
+const MOVIE_RANGE_FETCH_LIMIT = Math.max(
+  1,
+  Number(process.env.MOVIE_CATALOG_RANGE_FETCH_LIMIT) || 2
+);
+const NEW_RELEASE_CACHE_COLLECTION = 'movieNewReleases';
+const NEW_RELEASE_CACHE_VERSION = 'v1';
+const NEW_RELEASE_CACHE_TTL_MS = Math.max(
+  60 * 60 * 1000,
+  Number(process.env.MOVIE_NEW_RELEASE_CACHE_TTL_MS) || 24 * 60 * 60 * 1000
+);
+const NEW_RELEASE_CACHE_LIMIT = Math.max(
+  10,
+  Number(process.env.MOVIE_NEW_RELEASE_CACHE_LIMIT) || 50
+);
 const LOCAL_CACHE_PATH = path.join(__dirname, 'movie-catalog.json');
 const REFRESH_INTERVAL_MS = Math.max(
   60_000,
@@ -128,6 +167,30 @@ function formatMovieForResponse(movie, source = 'catalog') {
   };
 }
 
+function stripDerivedMovieFields(movie) {
+  if (!movie) return null;
+  const id = movie.id == null ? null : String(movie.id);
+  const title = typeof movie.title === 'string' ? movie.title : '';
+  if (!id || !title) return null;
+  const score = Number(movie.score);
+  if (!Number.isFinite(score)) return null;
+  const releaseDate = typeof movie.releaseDate === 'string' && movie.releaseDate ? movie.releaseDate : null;
+  const voteCount = Number.isFinite(Number(movie.voteCount)) ? Number(movie.voteCount) : null;
+  const popularity = Number.isFinite(Number(movie.popularity)) ? Number(movie.popularity) : null;
+  return {
+    id,
+    title,
+    score,
+    releaseDate,
+    voteCount,
+    popularity
+  };
+}
+
+function prepareMoviesForCache(movies) {
+  return (Array.isArray(movies) ? movies : []).map(stripDerivedMovieFields).filter(Boolean);
+}
+
 function applyState(movies, metadata = {}) {
   const prepared = Array.isArray(movies)
     ? movies
@@ -185,14 +248,7 @@ async function persistCatalog() {
   const payload = {
     updatedAt: new Date(state.updatedAt).toISOString(),
     metadata: { ...state.metadata, total: state.movies.length },
-    movies: state.movies.map(movie => ({
-      id: movie.id,
-      title: movie.title,
-      score: movie.score,
-      releaseDate: movie.releaseDate,
-      voteCount: movie.voteCount,
-      popularity: movie.popularity
-    }))
+    movies: state.movies.map(stripDerivedMovieFields).filter(Boolean)
   };
   const body = JSON.stringify(payload);
   const tasks = [];
@@ -219,6 +275,185 @@ async function persistCatalog() {
     })
   );
   await Promise.all(tasks);
+}
+
+function buildReleaseRanges() {
+  const ranges = [];
+  const span = Math.max(1, Number(MOVIE_RANGE_SPAN_YEARS) || 1);
+  const minYear = Math.max(1900, Number(MOVIE_RANGE_MIN_YEAR) || 1900);
+  const maxYear = Math.max(minYear, Number(MOVIE_RANGE_MAX_YEAR) || minYear);
+  for (let endYear = maxYear; endYear >= minYear; endYear -= span) {
+    const startYear = Math.max(minYear, endYear - span + 1);
+    const startDate = `${String(startYear).padStart(4, '0')}-01-01`;
+    const endDate = `${String(endYear).padStart(4, '0')}-12-31`;
+    ranges.push({
+      startYear,
+      endYear,
+      startDate,
+      endDate,
+      label: `${startYear}-${endYear}`
+    });
+  }
+  return ranges;
+}
+
+function rangeCacheParts(range) {
+  return ['range', MOVIE_RANGE_CACHE_VERSION, range.startDate, range.endDate];
+}
+
+async function loadRangeFromCache(range) {
+  const cached = await readCachedResponse(
+    MOVIE_RANGE_CACHE_COLLECTION,
+    rangeCacheParts(range),
+    MOVIE_RANGE_CACHE_TTL_MS
+  );
+  if (!cached || typeof cached.body !== 'string' || !cached.body.length) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(cached.body);
+    const rawMovies = Array.isArray(parsed?.movies) ? parsed.movies : [];
+    const movies = rawMovies.map(movie => normalizeMovie(movie)).filter(Boolean);
+    if (!movies.length) return null;
+    const fetchedAt = (() => {
+      if (parsed?.range?.fetchedAt && typeof parsed.range.fetchedAt === 'string') {
+        return parsed.range.fetchedAt;
+      }
+      if (cached.metadata && typeof cached.metadata.fetchedAt === 'string') {
+        return cached.metadata.fetchedAt;
+      }
+      return null;
+    })();
+    const total = Number(parsed?.range?.total || cached.metadata?.total || movies.length) || movies.length;
+    const metadata = {
+      source: 'cache',
+      fetchedAt,
+      total,
+      label: range.label,
+      startDate: range.startDate,
+      endDate: range.endDate,
+      tmdbTotalResults:
+        Number(parsed?.range?.totalResults ?? cached.metadata?.tmdbTotalResults) || null,
+      tmdbTotalPages:
+        Number(parsed?.range?.totalPages ?? cached.metadata?.tmdbTotalPages) || null
+    };
+    return { range, movies, metadata };
+  } catch (err) {
+    console.error(`Failed to parse cached TMDB range ${range.label}`, err);
+    return null;
+  }
+}
+
+async function cacheRangeMovies(range, movies, metadata = {}) {
+  const sanitizedMovies = prepareMoviesForCache(movies);
+  if (!sanitizedMovies.length) return;
+  const fetchedAt = new Date().toISOString();
+  const body = JSON.stringify({
+    range: {
+      label: range.label,
+      startDate: range.startDate,
+      endDate: range.endDate,
+      fetchedAt,
+      total: sanitizedMovies.length,
+      totalResults:
+        Number.isFinite(Number(metadata.totalResults)) && Number(metadata.totalResults) > 0
+          ? Number(metadata.totalResults)
+          : undefined,
+      totalPages:
+        Number.isFinite(Number(metadata.totalPages)) && Number(metadata.totalPages) > 0
+          ? Number(metadata.totalPages)
+          : undefined
+    },
+    movies: sanitizedMovies
+  });
+  const cacheMetadata = {
+    label: range.label,
+    startDate: range.startDate,
+    endDate: range.endDate,
+    total: sanitizedMovies.length,
+    fetchedAt,
+    tmdbTotalResults:
+      Number.isFinite(Number(metadata.totalResults)) && Number(metadata.totalResults) > 0
+        ? Number(metadata.totalResults)
+        : null,
+    tmdbTotalPages:
+      Number.isFinite(Number(metadata.totalPages)) && Number(metadata.totalPages) > 0
+        ? Number(metadata.totalPages)
+        : null,
+    version: MOVIE_RANGE_CACHE_VERSION
+  };
+  try {
+    await writeCachedResponse(MOVIE_RANGE_CACHE_COLLECTION, rangeCacheParts(range), {
+      status: 200,
+      contentType: 'application/json',
+      body,
+      metadata: cacheMetadata
+    });
+  } catch (err) {
+    console.error(`Failed to cache TMDB range ${range.label}`, err);
+  }
+}
+
+function mergeRangeMovies(rangeEntries) {
+  const merged = new Map();
+  for (const entry of rangeEntries) {
+    if (!entry || !Array.isArray(entry.movies)) continue;
+    for (const movie of entry.movies) {
+      if (!movie || movie.id == null) continue;
+      const key = String(movie.id);
+      if (!merged.has(key)) {
+        merged.set(key, movie);
+      } else {
+        const existing = merged.get(key);
+        if ((movie.ranking ?? 0) > (existing.ranking ?? 0)) {
+          merged.set(key, movie);
+        }
+      }
+    }
+  }
+  return Array.from(merged.values()).sort((a, b) => (b.ranking ?? 0) - (a.ranking ?? 0));
+}
+
+function summarizeRangeMetadata(rangeEntries, aggregatedMovies, totalConfiguredRanges, fetchedThisRun) {
+  let cachedCount = 0;
+  let fetchedCount = 0;
+  const coverageYears = [];
+  const fetchedTimestamps = [];
+  for (const entry of rangeEntries) {
+    if (!entry) continue;
+    if (entry.metadata?.source === 'tmdb') {
+      fetchedCount += 1;
+    } else {
+      cachedCount += 1;
+    }
+    if (entry.range) {
+      if (Number.isFinite(entry.range.startYear)) coverageYears.push(entry.range.startYear);
+      if (Number.isFinite(entry.range.endYear)) coverageYears.push(entry.range.endYear);
+    }
+    const fetchedAtMs = parseDate(entry.metadata?.fetchedAt);
+    if (Number.isFinite(fetchedAtMs)) {
+      fetchedTimestamps.push(fetchedAtMs);
+    }
+  }
+  const latestFetchedMs = fetchedTimestamps.length ? Math.max(...fetchedTimestamps) : null;
+  const minYear = coverageYears.length ? Math.min(...coverageYears) : null;
+  const maxYear = coverageYears.length ? Math.max(...coverageYears) : null;
+  return {
+    source: 'tmdb-range-cache',
+    totalCollected: aggregatedMovies.length,
+    rangeVersion: MOVIE_RANGE_CACHE_VERSION,
+    rangeSpanYears: MOVIE_RANGE_SPAN_YEARS,
+    configuredRanges: totalConfiguredRanges,
+    coveredRanges: rangeEntries.length,
+    missingRanges: Math.max(0, totalConfiguredRanges - rangeEntries.length),
+    fetchedRanges: fetchedCount,
+    cachedRanges: cachedCount,
+    fetchedThisRun,
+    minYear,
+    maxYear,
+    rangeCacheTtlMs: MOVIE_RANGE_CACHE_TTL_MS,
+    fetchedAt: latestFetchedMs ? new Date(latestFetchedMs).toISOString() : null
+  };
 }
 
 async function tmdbRequest(pathname, params, credentials) {
@@ -282,6 +517,63 @@ async function fetchCatalogFromTmdb(credentials) {
   };
 }
 
+async function fetchRangeCatalog(range, credentials) {
+  const params = new URLSearchParams({
+    sort_by: 'vote_average.desc',
+    vote_average: `gte:${MIN_SCORE}`,
+    'vote_average.gte': String(MIN_SCORE),
+    'vote_count.gte': '200',
+    include_adult: 'false',
+    include_video: 'false',
+    language: 'en-US',
+    'primary_release_date.gte': range.startDate,
+    'primary_release_date.lte': range.endDate
+  });
+  const seen = new Map();
+  let pagesFetched = 0;
+  let totalPages = Infinity;
+  let totalResults = null;
+  for (let page = 1; page <= MAX_DISCOVER_PAGES && page <= totalPages; page += 1) {
+    params.set('page', String(page));
+    const data = await tmdbRequest('discover/movie', params, credentials);
+    const results = Array.isArray(data?.results) ? data.results : [];
+    for (const item of results) {
+      const movie = normalizeMovie(item);
+      if (!movie || movie.id == null) continue;
+      const key = String(movie.id);
+      const existing = seen.get(key);
+      if (!existing || (movie.ranking ?? 0) > (existing.ranking ?? 0)) {
+        seen.set(key, movie);
+      }
+    }
+    pagesFetched = page;
+    const reportedTotalPages = Number(data?.total_pages);
+    if (Number.isFinite(reportedTotalPages) && reportedTotalPages > 0) {
+      totalPages = reportedTotalPages;
+    }
+    const reportedTotalResults = Number(data?.total_results);
+    if (Number.isFinite(reportedTotalResults) && reportedTotalResults >= 0) {
+      totalResults = reportedTotalResults;
+    }
+    if (!results.length && (!Number.isFinite(totalPages) || page >= totalPages)) {
+      break;
+    }
+  }
+  const movies = Array.from(seen.values()).sort((a, b) => (b.ranking ?? 0) - (a.ranking ?? 0));
+  return {
+    range,
+    movies,
+    metadata: {
+      source: 'tmdb',
+      label: range.label,
+      totalCollected: movies.length,
+      fetchedPages: pagesFetched,
+      totalPages: Number.isFinite(totalPages) ? totalPages : null,
+      totalResults: Number.isFinite(totalResults) ? totalResults : null
+    }
+  };
+}
+
 async function fetchLegacyCatalog() {
   const url =
     'https://raw.githubusercontent.com/FEND16/movie-json-data/master/json/top-rated-movies-01.json';
@@ -319,17 +611,77 @@ async function fetchLegacyCatalog() {
 
 async function fetchCuratedCatalog() {
   const credentials = getTmdbCredentials();
-  if (credentials) {
+  if (!credentials) {
+    return fetchLegacyCatalog();
+  }
+
+  const ranges = buildReleaseRanges();
+  if (!ranges.length) {
+    try {
+      return await fetchCatalogFromTmdb(credentials);
+    } catch (err) {
+      console.error('TMDB catalog fetch failed', err);
+      return fetchLegacyCatalog();
+    }
+  }
+
+  const preparedRanges = [];
+  const missingRanges = [];
+
+  for (const range of ranges) {
+    // eslint-disable-next-line no-await-in-loop
+    const cached = await loadRangeFromCache(range);
+    if (cached) {
+      preparedRanges.push(cached);
+    } else {
+      missingRanges.push(range);
+    }
+  }
+
+  let fetchedThisRun = 0;
+  if (missingRanges.length) {
+    for (const range of missingRanges) {
+      if (fetchedThisRun >= MOVIE_RANGE_FETCH_LIMIT) break;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await fetchRangeCatalog(range, credentials);
+        if (Array.isArray(result.movies) && result.movies.length) {
+          preparedRanges.push({
+            range: result.range,
+            movies: result.movies,
+            metadata: { ...result.metadata, source: 'tmdb' }
+          });
+          fetchedThisRun += 1;
+          // eslint-disable-next-line no-await-in-loop
+          await cacheRangeMovies(range, result.movies, result.metadata);
+        }
+      } catch (err) {
+        console.error(`TMDB range fetch failed for ${range.label}`, err);
+      }
+    }
+  }
+
+  if (!preparedRanges.length) {
     try {
       const catalog = await fetchCatalogFromTmdb(credentials);
       if (Array.isArray(catalog.movies) && catalog.movies.length) {
         return catalog;
       }
     } catch (err) {
-      console.error('TMDB catalog fetch failed', err);
+      console.error('TMDB catalog fetch fallback failed', err);
     }
+    return fetchLegacyCatalog();
   }
-  return fetchLegacyCatalog();
+
+  const aggregatedMovies = mergeRangeMovies(preparedRanges);
+  const metadata = summarizeRangeMetadata(
+    preparedRanges,
+    aggregatedMovies,
+    ranges.length,
+    fetchedThisRun
+  );
+
+  return { movies: aggregatedMovies, metadata };
 }
 
 async function hydrateFromStorage() {
@@ -468,6 +820,73 @@ function recentThresholdDate() {
   return new Date(thresholdMs).toISOString().slice(0, 10);
 }
 
+function newReleaseCacheParts(query) {
+  const normalized = String(query || '').trim().toLowerCase();
+  return ['releases', NEW_RELEASE_CACHE_VERSION, normalized || 'default'];
+}
+
+async function loadCachedNewReleases(query) {
+  const cached = await readCachedResponse(
+    NEW_RELEASE_CACHE_COLLECTION,
+    newReleaseCacheParts(query),
+    NEW_RELEASE_CACHE_TTL_MS
+  );
+  if (!cached || typeof cached.body !== 'string' || !cached.body.length) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(cached.body);
+    const rawMovies = Array.isArray(parsed?.movies) ? parsed.movies : [];
+    const movies = rawMovies
+      .map(item => normalizeMovie(item, { allowLowScore: true }))
+      .filter(Boolean)
+      .sort((a, b) => (b.ranking ?? 0) - (a.ranking ?? 0));
+    if (!movies.length) return null;
+    return {
+      movies,
+      metadata: {
+        ...(parsed?.metadata && typeof parsed.metadata === 'object' ? parsed.metadata : {}),
+        source: 'cache'
+      }
+    };
+  } catch (err) {
+    console.error('Failed to parse cached new release movies', err);
+    return null;
+  }
+}
+
+async function cacheNewReleases(query, movies, metadata = {}) {
+  const sanitizedMovies = prepareMoviesForCache(movies).slice(0, NEW_RELEASE_CACHE_LIMIT);
+  if (!sanitizedMovies.length) return;
+  const fetchedAt = new Date().toISOString();
+  const payload = {
+    metadata: {
+      source: 'tmdb',
+      query: query || null,
+      fetchedAt,
+      total: sanitizedMovies.length,
+      ...(metadata && typeof metadata === 'object' ? metadata : {})
+    },
+    movies: sanitizedMovies
+  };
+  const cacheMetadata = {
+    fetchedAt,
+    query: query || null,
+    total: sanitizedMovies.length,
+    version: NEW_RELEASE_CACHE_VERSION
+  };
+  try {
+    await writeCachedResponse(NEW_RELEASE_CACHE_COLLECTION, newReleaseCacheParts(query), {
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+      metadata: cacheMetadata
+    });
+  } catch (err) {
+    console.error('Failed to cache new release movies', err);
+  }
+}
+
 function filterFreshResults(results, { allowLowScore = true, excludeIds }) {
   const exclude = new Set((excludeIds || []).map(id => String(id)));
   const threshold = recentThresholdDate();
@@ -491,55 +910,106 @@ async function fetchNewReleases({ query = '', limit = 10, excludeIds = [] } = {}
   if (!credentials) return [];
   const sanitizedLimit = Math.max(1, Number(limit) || 10);
   const normalizedQuery = String(query || '').trim();
-  const collected = [];
-  const seen = new Set();
+  const excludeList = Array.isArray(excludeIds) ? excludeIds.map(id => String(id)) : [];
 
-  const pushMovies = movies => {
-    for (const movie of movies) {
-      if (!movie) continue;
-      if (seen.has(movie.id)) continue;
-      seen.add(movie.id);
-      collected.push(formatMovieForResponse(movie, 'fresh'));
-      if (collected.length >= sanitizedLimit) break;
+  let prepared = null;
+  try {
+    prepared = await loadCachedNewReleases(normalizedQuery);
+    if (prepared && (!Array.isArray(prepared.movies) || !prepared.movies.length)) {
+      prepared = null;
     }
-  };
+  } catch (err) {
+    console.error('Failed to load cached new releases', err);
+    prepared = null;
+  }
 
-  if (normalizedQuery) {
-    try {
-      const params = new URLSearchParams({
-        query: normalizedQuery,
-        include_adult: 'false',
-        language: 'en-US',
-        page: '1'
-      });
-      const data = await tmdbRequest('search/movie', params, credentials);
-      const movies = filterFreshResults(data?.results, { excludeIds });
-      pushMovies(movies);
-    } catch (err) {
-      console.error('TMDB search for new releases failed', err);
+  let normalizedResults = Array.isArray(prepared?.movies) ? prepared.movies : null;
+  if (!normalizedResults) {
+    const seen = new Map();
+    const pushMovies = movies => {
+      for (const movie of movies) {
+        if (!movie || movie.id == null) continue;
+        const key = String(movie.id);
+        const existing = seen.get(key);
+        if (!existing || (movie.ranking ?? 0) > (existing.ranking ?? 0)) {
+          seen.set(key, movie);
+        }
+      }
+    };
+
+    let usedSearch = false;
+    if (normalizedQuery) {
+      try {
+        const params = new URLSearchParams({
+          query: normalizedQuery,
+          include_adult: 'false',
+          language: 'en-US',
+          page: '1'
+        });
+        const data = await tmdbRequest('search/movie', params, credentials);
+        const movies = filterFreshResults(data?.results, { excludeIds: excludeList });
+        pushMovies(movies);
+        usedSearch = true;
+      } catch (err) {
+        console.error('TMDB search for new releases failed', err);
+      }
+    }
+
+    let usedDiscover = false;
+    if (seen.size < NEW_RELEASE_CACHE_LIMIT) {
+      try {
+        const params = new URLSearchParams({
+          sort_by: 'primary_release_date.desc',
+          include_adult: 'false',
+          include_video: 'false',
+          language: 'en-US',
+          page: '1',
+          'primary_release_date.gte': recentThresholdDate(),
+          with_release_type: '2|3'
+        });
+        const data = await tmdbRequest('discover/movie', params, credentials);
+        const movies = filterFreshResults(data?.results, { excludeIds: excludeList });
+        pushMovies(movies);
+        usedDiscover = true;
+      } catch (err) {
+        console.error('TMDB new release fetch failed', err);
+      }
+    }
+
+    normalizedResults = Array.from(seen.values()).sort((a, b) => (b.ranking ?? 0) - (a.ranking ?? 0));
+
+    if (normalizedResults.length) {
+      try {
+        await cacheNewReleases(normalizedQuery, normalizedResults, {
+          searchUsed: usedSearch,
+          discoverUsed: usedDiscover
+        });
+      } catch (err) {
+        console.error('Failed to cache new release results', err);
+      }
     }
   }
 
-  if (collected.length < sanitizedLimit) {
-    try {
-      const params = new URLSearchParams({
-        sort_by: 'primary_release_date.desc',
-        include_adult: 'false',
-        include_video: 'false',
-        language: 'en-US',
-        page: '1',
-        'primary_release_date.gte': recentThresholdDate(),
-        with_release_type: '2|3'
-      });
-      const data = await tmdbRequest('discover/movie', params, credentials);
-      const movies = filterFreshResults(data?.results, { excludeIds });
-      pushMovies(movies);
-    } catch (err) {
-      console.error('TMDB new release fetch failed', err);
-    }
+  if (!normalizedResults || !normalizedResults.length) {
+    return [];
   }
 
-  return collected.slice(0, sanitizedLimit);
+  const filtered = filterFreshResults(normalizedResults, {
+    allowLowScore: true,
+    excludeIds: excludeList
+  });
+  const results = [];
+  const seenIds = new Set();
+  for (const movie of filtered) {
+    if (!movie || movie.id == null) continue;
+    const key = String(movie.id);
+    if (seenIds.has(key)) continue;
+    seenIds.add(key);
+    results.push(formatMovieForResponse(movie, 'fresh'));
+    if (results.length >= sanitizedLimit) break;
+  }
+
+  return results;
 }
 
 function stop() {


### PR DESCRIPTION
## Summary
- cache TMDB catalog pages by release-year ranges and merge them into the curated catalog
- persist normalized movie data for reuse and update metadata describing cache coverage
- cache new-release queries so TMDB is only hit daily and reuse cached data when possible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5484f26b88327b80a7731045f823a