### PR TITLE
Normalize Spotify redirect URI for PKCE flow

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -1177,7 +1177,8 @@ export async function initShowsPanel() {
     apiKeyInput.style.display = 'none';
   }
 
-  const redirectUri = window.location.origin + window.location.pathname;
+  const canonicalPath = window.location.pathname.replace(/index\.html$/, '');
+  const redirectUri = window.location.origin + (canonicalPath || '/');
 
   const updateSpotifyStatus = () => {
     const storedToken =


### PR DESCRIPTION
## Summary
- strip a trailing `index.html` from the Shows panel redirect URI so the PKCE flow matches Spotify dashboard entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e549d5e0f08327a27f539415026013