### PR TITLE
Disable Eventbrite discovery when Spotify is disconnected

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -1069,16 +1069,38 @@ export async function initShowsPanel() {
   const artistLimitInput = document.getElementById('showsArtistLimit');
   const includeSuggestionsInput = document.getElementById('showsIncludeSuggestions');
 
-  const setDiscoverButtonState = isLoading => {
+  const getStoredSpotifyToken = () =>
+    (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
+
+  let discoverBtnIsLoading = false;
+
+  const refreshDiscoverButtonState = () => {
     if (!discoverBtn) return;
     if (!discoverBtn.dataset.defaultText) {
       discoverBtn.dataset.defaultText = discoverBtn.textContent.trim() || 'Discover';
     }
-    discoverBtn.disabled = isLoading;
-    discoverBtn.classList.toggle('is-loading', isLoading);
-    discoverBtn.textContent = isLoading
+
+    const hasSpotifyToken = Boolean(getStoredSpotifyToken());
+    const shouldDisable = discoverBtnIsLoading || !hasSpotifyToken;
+
+    discoverBtn.disabled = shouldDisable;
+    discoverBtn.classList.toggle('is-loading', discoverBtnIsLoading);
+    discoverBtn.textContent = discoverBtnIsLoading
       ? 'Loading…'
       : discoverBtn.dataset.defaultText;
+
+    if (!hasSpotifyToken) {
+      discoverBtn.title = 'Connect Spotify to discover live music near you.';
+      discoverBtn.setAttribute('aria-disabled', 'true');
+    } else {
+      discoverBtn.removeAttribute('title');
+      discoverBtn.removeAttribute('aria-disabled');
+    }
+  };
+
+  const setDiscoverButtonState = isLoading => {
+    discoverBtnIsLoading = Boolean(isLoading);
+    refreshDiscoverButtonState();
   };
 
   const applyConfigToInputs = config => {
@@ -1180,8 +1202,7 @@ export async function initShowsPanel() {
   const redirectUri = window.location.origin + window.location.pathname;
 
   const updateSpotifyStatus = () => {
-    const storedToken =
-      (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
+    const storedToken = getStoredSpotifyToken();
     if (tokenBtn) {
       tokenBtn.textContent = storedToken ? 'Reconnect Spotify' : 'Login to Spotify';
     }
@@ -1189,6 +1210,7 @@ export async function initShowsPanel() {
       statusEl.textContent = storedToken ? 'Spotify connected' : 'Not connected';
       statusEl.classList.toggle('shows-spotify-status', Boolean(storedToken));
     }
+    refreshDiscoverButtonState();
   };
 
   if (statusEl) {
@@ -1272,8 +1294,7 @@ export async function initShowsPanel() {
     const { radiusMiles, artistLimit, includeSuggestions } = readConfigFromInputs();
     lastRequestedRadiusMiles = radiusMiles;
 
-    const token =
-      (typeof localStorage !== 'undefined' && localStorage.getItem('spotifyToken')) || '';
+    const token = getStoredSpotifyToken();
     const manualApiToken =
       apiKeyInput?.value.trim() ||
       (typeof localStorage !== 'undefined' && localStorage.getItem('eventbriteApiToken')) || '';


### PR DESCRIPTION
## Summary
- disable the Eventbrite "Discover" button until a Spotify token is available
- centralize Spotify token lookup so status text and button state stay in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e54a2e9a9083278a6991f1abe96918