### PR TITLE
Stop retrying unsupported TMDB movie details endpoint

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -1015,6 +1015,12 @@ async function fetchCreditsViaDetailsFromProxy(movieId) {
       }
       return null;
     } catch (err) {
+      if (err && err.status === 400 && !isProxyParameterError(err)) {
+        unsupportedProxyEndpoints.add('movie_details');
+        if (!err.code) {
+          err.code = 'unsupported_endpoint';
+        }
+      }
       if (!isProxyParameterError(err)) {
         throw err;
       }


### PR DESCRIPTION
## Summary
- mark the TMDB movie_details proxy endpoint as unsupported when it returns a 400 without an error code
- prevent repeated fallback requests by tagging the error as an unsupported endpoint

## Testing
- `vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68e54f828a4c8327aab2ee9f8dc27914