### PR TITLE
Allow submitting Eventbrite token with Enter key

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -1577,6 +1577,21 @@ export async function initShowsPanel() {
     discoverBtn.addEventListener('click', handler);
   }
 
+  if (apiKeyInput) {
+    if (apiKeyInput._showsEnterHandler) {
+      apiKeyInput.removeEventListener('keydown', apiKeyInput._showsEnterHandler);
+    }
+    const handler = event => {
+      if (event.key === 'Enter' || event.key === 'NumpadEnter') {
+        event.preventDefault();
+        if (discoverBtnIsLoading) return;
+        loadShows({ triggeredByUser: true });
+      }
+    };
+    apiKeyInput._showsEnterHandler = handler;
+    apiKeyInput.addEventListener('keydown', handler);
+  }
+
   await loadShows();
 }
 

--- a/tests/showsSpotify.test.js
+++ b/tests/showsSpotify.test.js
@@ -576,6 +576,35 @@ describe('initShowsPanel', () => {
     expect(fetch.mock.calls[2][0]).toContain('token=manualKey');
   });
 
+  it('allows submitting manual Eventbrite token via Enter key', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ clientId: 'cid', hasEventbriteToken: false }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [{ name: 'Artist' }] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeEventbriteResponse([
+            makeEventbriteEvent({ id: 'enter', name: 'Enter Show', artists: ['Artist'] })
+          ])
+      });
+
+    localStorage.setItem('spotifyToken', 'token');
+
+    await initShowsPanel();
+    await flush();
+
+    const input = document.getElementById('eventbriteApiToken');
+    input.value = 'enterKey';
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+
+    await flush();
+    await flush();
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch.mock.calls[2][0]).toContain('/api/eventbrite');
+    expect(fetch.mock.calls[2][0]).toContain('token=enterKey');
+  });
+
   it('shows Spotify suggestions when no live shows are available', async () => {
     fetch
       .mockResolvedValueOnce({ ok: true, json: async () => ({ clientId: 'cid', hasEventbriteToken: true }) })


### PR DESCRIPTION
## Summary
- trigger live music discovery when the Eventbrite token input receives an Enter keypress, matching the discover button behavior
- guard against duplicate submissions while the discover request is running
- cover manual token submission via the Enter key with a unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e56fcfc5ac83279d96ebd733d723cb