### PR TITLE
Increase restaurants fetch limit and test coverage

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -4,6 +4,8 @@ const API_BASE_URL =
   (typeof window !== 'undefined' && window.location?.origin) ||
   'https://us-central1-decision-maker-4e1d3.cloudfunctions.net';
 
+const TARGET_NEARBY_RESULTS = 60;
+
 let initialized = false;
 let mapInstance = null;
 let mapMarkersLayer = null;
@@ -873,6 +875,10 @@ async function fetchRestaurants({ latitude, longitude, city, skipCoordinates = f
   const hasLatitude = Number.isFinite(parsedLatitude);
   const hasLongitude = Number.isFinite(parsedLongitude);
   const shouldIncludeCoords = !skipCoordinates && hasLatitude && hasLongitude;
+
+  if (Number.isFinite(TARGET_NEARBY_RESULTS) && TARGET_NEARBY_RESULTS > 0) {
+    params.set('limit', String(TARGET_NEARBY_RESULTS));
+  }
 
   if (shouldIncludeCoords) {
     params.set('latitude', String(parsedLatitude));

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -78,6 +78,7 @@ describe('initRestaurantsPanel', () => {
     expect(fetch.mock.calls[0][0]).toContain('reverse');
     expect(fetch.mock.calls[1][0]).toContain('latitude=30.2672');
     expect(fetch.mock.calls[1][0]).toContain('longitude=-97.7431');
+    expect(fetch.mock.calls[1][0]).toContain('limit=60');
     expect(fetch.mock.calls[1][0]).toContain('city=Austin');
 
     const results = document.getElementById('restaurantsResults');
@@ -227,7 +228,9 @@ describe('initRestaurantsPanel', () => {
     expect(fetch).toHaveBeenCalledTimes(3);
     expect(fetch.mock.calls[1][0]).toContain('latitude=30.2672');
     expect(fetch.mock.calls[1][0]).toContain('longitude=-97.7431');
+    expect(fetch.mock.calls[1][0]).toContain('limit=60');
     expect(fetch.mock.calls[2][0]).toContain('city=Austin');
+    expect(fetch.mock.calls[2][0]).toContain('limit=60');
     expect(fetch.mock.calls[2][0]).not.toContain('latitude=');
     expect(fetch.mock.calls[2][0]).not.toContain('longitude=');
 


### PR DESCRIPTION
## Summary
- request a larger batch of nearby restaurants when loading the panel so more results display
- assert the restaurants queries include the new limit parameter in unit tests

## Testing
- npm test -- restaurants
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e57b55b0dc832799158e096479bb87