### PR TITLE
Add shared API base resolver with cloud fallback

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,46 @@
+const DEFAULT_REMOTE_API_BASE = 'https://us-central1-decision-maker-4e1d3.cloudfunctions.net';
+
+function isLocalHost(hostname) {
+  if (!hostname) return false;
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1' ||
+    normalized === '[::1]' ||
+    normalized.endsWith('.local')
+  );
+}
+
+function resolveDefaultApiBase() {
+  if (typeof window === 'undefined') {
+    return DEFAULT_REMOTE_API_BASE;
+  }
+
+  const { location } = window;
+  if (!location) {
+    return DEFAULT_REMOTE_API_BASE;
+  }
+
+  const { protocol, origin, hostname } = location;
+  if (protocol === 'file:') {
+    return DEFAULT_REMOTE_API_BASE;
+  }
+
+  if (isLocalHost(hostname)) {
+    return origin || '';
+  }
+
+  if (!hostname) {
+    return DEFAULT_REMOTE_API_BASE;
+  }
+
+  return DEFAULT_REMOTE_API_BASE;
+}
+
+export const API_BASE_URL =
+  (typeof window !== 'undefined' && window.apiBaseUrl) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_BASE_URL) ||
+  resolveDefaultApiBase();
+
+export { DEFAULT_REMOTE_API_BASE };

--- a/js/movies.js
+++ b/js/movies.js
@@ -1,10 +1,5 @@
 import { getCurrentUser, awaitAuthUser, db } from './auth.js';
-
-const API_BASE_URL =
-  (typeof window !== 'undefined' && window.apiBaseUrl) ||
-  (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
-  (typeof window !== 'undefined' && window.location?.origin) ||
-  '';
+import { API_BASE_URL, DEFAULT_REMOTE_API_BASE } from './config.js';
 
 const MOVIE_PREFS_KEY = 'moviePreferences';
 const API_KEY_STORAGE = 'moviesApiKey';
@@ -21,7 +16,7 @@ const MIN_FEED_RESULTS = 10;
 
 const DEFAULT_TMDB_PROXY_ENDPOINT =
   (typeof process !== 'undefined' && process.env && process.env.TMDB_PROXY_ENDPOINT) ||
-  'https://us-central1-decision-maker-4e1d3.cloudfunctions.net/tmdbProxy';
+  `${DEFAULT_REMOTE_API_BASE}/tmdbProxy`;
 
 let proxyDisabled = false;
 const unsupportedProxyEndpoints = new Set();

--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -1,8 +1,6 @@
-const API_BASE_URL =
-  (typeof window !== 'undefined' && window.apiBaseUrl) ||
-  (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
-  (typeof window !== 'undefined' && window.location?.origin) ||
-  'https://us-central1-decision-maker-4e1d3.cloudfunctions.net';
+import { API_BASE_URL, DEFAULT_REMOTE_API_BASE } from './config.js';
+
+const FALLBACK_API_BASE = DEFAULT_REMOTE_API_BASE;
 
 const TARGET_NEARBY_RESULTS = 60;
 
@@ -38,7 +36,8 @@ function buildRestaurantsUrl(params) {
   const rawBase =
     API_BASE_URL && API_BASE_URL !== 'null' ? API_BASE_URL : '';
   if (!rawBase) {
-    return `/api/restaurants?${query}`;
+    const fallbackBase = FALLBACK_API_BASE.replace(/\/$/, '');
+    return `${fallbackBase}/restaurantsProxy?${query}`;
   }
   const trimmedBase = rawBase.replace(/\/$/, '');
   if (trimmedBase.endsWith('/api/restaurants') || trimmedBase.endsWith('/restaurantsProxy')) {

--- a/js/shows.js
+++ b/js/shows.js
@@ -1,13 +1,10 @@
-const API_BASE_URL =
-  (typeof window !== 'undefined' && window.apiBaseUrl) ||
-  (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
+import { API_BASE_URL, DEFAULT_REMOTE_API_BASE } from './config.js';
 
 const DEFAULT_EVENTBRITE_ENDPOINT =
   (typeof process !== 'undefined' &&
     process.env &&
     (process.env.EVENTBRITE_ENDPOINT || process.env.EVENTBRITE_PROXY_ENDPOINT)) ||
-  'https://us-central1-decision-maker-4e1d3.cloudfunctions.net/eventbriteProxy';
+  `${DEFAULT_REMOTE_API_BASE}/eventbriteProxy`;
 
 function normalizeEndpoint(value) {
   return typeof value === 'string' ? value.trim() : '';


### PR DESCRIPTION
## Summary
- add a shared config module that resolves API_BASE_URL with a Firebase Functions fallback
- update the shows, movies, and restaurants modules to consume the shared configuration and reuse the remote defaults
- ensure restaurant searches fall back to the deployed proxy when no local API base is configured

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5852725888327804098d039740019