### PR TITLE
Sort saved restaurants by proximity

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -119,7 +119,9 @@ function writeStoredList(key, list) {
 }
 
 function loadStoredState() {
-  savedRestaurants = dedupeRestaurants(readStoredList(STORAGE_KEYS.saved));
+  savedRestaurants = sortByDistance(
+    dedupeRestaurants(readStoredList(STORAGE_KEYS.saved))
+  );
   hiddenRestaurants = dedupeRestaurants(readStoredList(STORAGE_KEYS.hidden));
 }
 
@@ -144,7 +146,7 @@ function isHidden(id) {
 }
 
 function setSavedRestaurants(items) {
-  savedRestaurants = dedupeRestaurants(items);
+  savedRestaurants = sortByDistance(dedupeRestaurants(items));
   persistSaved();
 }
 


### PR DESCRIPTION
## Summary
- sort saved restaurant entries by distance when loading from storage
- ensure saved restaurants remain distance-ordered after any updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e58704ca148327ad78ded1c0c50d73