### PR TITLE
Support additional Eventbrite token environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The Eventbrite proxy performs a location-first search and the client highlights 
 2. Filters the returned events to your configured radius and promotes matches whose performers overlap with your top Spotify artists.
 3. Sorts events by proximity and renders ticket links, badges, and Interested/Not Interested actions in the dashboard.
 
-When Eventbrite asks for credentials, supply the **personal OAuth token** (labelled "private token" in their UI) that appears under **Account Settings → Developer → Your personal token**. The classic API key/secret pair does not authorize the Events Search endpoint, so the proxy will return HTTP 401 if you paste those values. You can also set the same personal token in `EVENTBRITE_API_TOKEN` (or `EVENTBRITE_OAUTH_TOKEN`) on the backend to avoid entering it in the browser.
+When Eventbrite asks for credentials, supply the **personal OAuth token** (labelled "private token" in their UI) that appears under **Account Settings → Developer → Your personal token**. The classic API key/secret pair does not authorize the Events Search endpoint, so the proxy will return HTTP 401 if you paste those values. You can also set the same personal token in `EVENTBRITE_API_TOKEN`, `EVENTBRITE_OAUTH_TOKEN`, or `EVENTBRITE_TOKEN` on the backend to avoid entering it in the browser.
 
 If no Eventbrite API token is available, Discover prompts for one and never transmits the request without explicit credentials.
 
@@ -107,7 +107,7 @@ Create a `.env` in the project root (and optionally `backend/.env`) with the cre
 | `PORT` | Express server | Override the default `3003` port. |
 | `HOST` | Express server | Bind address; defaults to `0.0.0.0`. |
 | `SPOTIFY_CLIENT_ID` | `/api/spotify-client-id` | PKCE client ID for Spotify login. |
-| `EVENTBRITE_API_TOKEN` or `EVENTBRITE_OAUTH_TOKEN` | Eventbrite proxy | Eventbrite personal token used for the Events Search API. |
+| `EVENTBRITE_API_TOKEN`, `EVENTBRITE_OAUTH_TOKEN`, or `EVENTBRITE_TOKEN` | Eventbrite proxy | Eventbrite personal token used for the Events Search API. |
 | `SPOONACULAR_KEY` | Spoonacular proxy | API key for recipe search. |
 | `YELP_API_KEY` | Restaurants proxy | Yelp Fusion API key if you do not pass one per request. |
 | `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV` | Plaid endpoints | Enable financial account linking workflows. |

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,7 +31,10 @@ movieCatalog
 const PORT = Number(process.env.PORT) || 3003;
 const HOST = process.env.HOST || (process.env.VITEST ? '127.0.0.1' : '0.0.0.0');
 const EVENTBRITE_API_TOKEN =
-  process.env.EVENTBRITE_API_TOKEN || process.env.EVENTBRITE_OAUTH_TOKEN || '';
+  process.env.EVENTBRITE_API_TOKEN ||
+  process.env.EVENTBRITE_OAUTH_TOKEN ||
+  process.env.EVENTBRITE_TOKEN ||
+  '';
 const HAS_EVENTBRITE_TOKEN = Boolean(EVENTBRITE_API_TOKEN);
 const YELP_BASE_URL = 'https://api.yelp.com/v3/businesses/search';
 const YELP_CACHE_COLLECTION = 'yelpCache';

--- a/tests/eventbriteTokenDetection.test.js
+++ b/tests/eventbriteTokenDetection.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+
+const ORIGINAL_ENV = { ...process.env };
+
+const resetEnv = () => {
+  if (ORIGINAL_ENV.EVENTBRITE_API_TOKEN === undefined) {
+    delete process.env.EVENTBRITE_API_TOKEN;
+  } else {
+    process.env.EVENTBRITE_API_TOKEN = ORIGINAL_ENV.EVENTBRITE_API_TOKEN;
+  }
+  if (ORIGINAL_ENV.EVENTBRITE_OAUTH_TOKEN === undefined) {
+    delete process.env.EVENTBRITE_OAUTH_TOKEN;
+  } else {
+    process.env.EVENTBRITE_OAUTH_TOKEN = ORIGINAL_ENV.EVENTBRITE_OAUTH_TOKEN;
+  }
+  if (ORIGINAL_ENV.EVENTBRITE_TOKEN === undefined) {
+    delete process.env.EVENTBRITE_TOKEN;
+  } else {
+    process.env.EVENTBRITE_TOKEN = ORIGINAL_ENV.EVENTBRITE_TOKEN;
+  }
+  if (ORIGINAL_ENV.SPOTIFY_CLIENT_ID === undefined) {
+    delete process.env.SPOTIFY_CLIENT_ID;
+  } else {
+    process.env.SPOTIFY_CLIENT_ID = ORIGINAL_ENV.SPOTIFY_CLIENT_ID;
+  }
+  if (ORIGINAL_ENV.NODE_ENV === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = ORIGINAL_ENV.NODE_ENV;
+  }
+};
+
+describe('spotify client id endpoint', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    delete process.env.EVENTBRITE_API_TOKEN;
+    delete process.env.EVENTBRITE_OAUTH_TOKEN;
+    delete process.env.EVENTBRITE_TOKEN;
+    delete process.env.SPOTIFY_CLIENT_ID;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    resetEnv();
+    vi.resetModules();
+  });
+
+  it('reports when an EVENTBRITE_TOKEN fallback is configured', async () => {
+    process.env.SPOTIFY_CLIENT_ID = 'cid-from-env';
+    process.env.EVENTBRITE_TOKEN = 'fallback-token';
+
+    const module = await import('../backend/server.js');
+    const app = module.default || module;
+
+    const res = await request(app).get('/api/spotify-client-id');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      clientId: 'cid-from-env',
+      hasEventbriteToken: true
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow the backend to treat EVENTBRITE_TOKEN as a valid Eventbrite credential, matching the serverless proxy
- document the extra variable in the setup guide
- add a regression test to ensure the Spotify client endpoint reports the token when only EVENTBRITE_TOKEN is set

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e587900a6483279a261e63c734d9f6