### PR TITLE
Hide saved restaurants from nearby feed

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -717,7 +717,9 @@ function renderNearbySection() {
   const container = domRefs.nearbyContainer;
   if (!container) return;
   if (isFetchingNearby && !nearbyRestaurants.length) return;
-  visibleNearbyRestaurants = nearbyRestaurants.filter(rest => !isHidden(rest.id));
+  visibleNearbyRestaurants = nearbyRestaurants.filter(
+    rest => !isHidden(rest.id) && !isSaved(rest.id)
+  );
   const emptyMessage = 'No restaurants found.';
   renderRestaurantsList(container, visibleNearbyRestaurants, emptyMessage);
 }

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -337,12 +337,16 @@ describe('initRestaurantsPanel', () => {
     const savedContainer = document.getElementById('restaurantsSaved');
     expect(savedContainer?.textContent).toContain('Top Rated');
 
-    const updatedSaveButton = document.querySelector('#restaurantsNearby .restaurant-action--secondary');
-    expect(updatedSaveButton).toBeTruthy();
-    expect(updatedSaveButton.textContent).toBe('Saved');
-    updatedSaveButton.click();
+    const nearbyContainer = document.getElementById('restaurantsNearby');
+    expect(nearbyContainer?.textContent).not.toContain('Top Rated');
+
+    const savedSectionButton = savedContainer?.querySelector('.restaurant-action--secondary');
+    expect(savedSectionButton).toBeTruthy();
+    expect(savedSectionButton?.textContent).toBe('Saved');
+    savedSectionButton?.click();
 
     expect(savedContainer?.textContent).toContain('No saved restaurants yet.');
+    expect(nearbyContainer?.textContent).toContain('Top Rated');
   });
 
   it('moves hidden restaurants to the hidden section', async () => {


### PR DESCRIPTION
## Summary
- filter the nearby restaurants list so saved entries only appear in the Saved tab
- adjust restaurant panel tests to reflect the new behavior when saving and unsaving

## Testing
- npm test -- restaurants

------
https://chatgpt.com/codex/tasks/task_e_68e58965db3c8327af6160b6ed81b39b