### PR TITLE
Filter nearby restaurants by review count

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -683,10 +683,24 @@ function sortByDistance(items) {
   });
 }
 
+function getReviewCountValue(rest) {
+  if (!rest || typeof rest !== 'object') return 0;
+
+  const raw =
+    typeof rest.reviewCount === 'number'
+      ? rest.reviewCount
+      : typeof rest.reviewCount === 'string'
+        ? Number(rest.reviewCount)
+        : NaN;
+
+  return Number.isFinite(raw) && raw >= 0 ? raw : 0;
+}
+
 function updateNearbyRestaurants() {
   const list = Array.isArray(rawNearbyRestaurants) ? rawNearbyRestaurants : [];
   const normalized = list.map(normalizeRestaurant).filter(Boolean);
-  nearbyRestaurants = sortByDistance(normalized);
+  const filtered = normalized.filter(rest => getReviewCountValue(rest) >= 5);
+  nearbyRestaurants = sortByDistance(filtered);
 }
 
 function renderRestaurantsList(container, items, emptyMessage) {


### PR DESCRIPTION
## Summary
- ensure nearby restaurant results exclude entries with fewer than five reviews by computing a numeric review count
- reuse the new review-count helper when preparing the sorted list of nearby restaurants

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e58c945ab0832792b2c929bab033ea