### PR TITLE
Add favorites tab and controls to restaurants panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
               aria-selected="true"
               aria-controls="restaurantsNearby"
             >
-              Nearby
+              Feed
             </button>
             <button
               type="button"
@@ -223,6 +223,17 @@
               aria-controls="restaurantsSaved"
             >
               Saved
+            </button>
+            <button
+              type="button"
+              id="restaurantsFavoritesTab"
+              class="restaurants-tab"
+              data-view="favorites"
+              role="tab"
+              aria-selected="false"
+              aria-controls="restaurantsFavorites"
+            >
+              Favorites
             </button>
           </div>
           <div
@@ -236,6 +247,13 @@
             class="restaurants-section"
             role="tabpanel"
             aria-labelledby="restaurantsSavedTab"
+            hidden
+          ></div>
+          <div
+            id="restaurantsFavorites"
+            class="restaurants-section"
+            role="tabpanel"
+            aria-labelledby="restaurantsFavoritesTab"
             hidden
           ></div>
           <div id="restaurantsHiddenSection" class="restaurants-hidden" aria-live="polite"></div>

--- a/style.css
+++ b/style.css
@@ -2979,6 +2979,19 @@ h2 {
   transform: none;
 }
 
+.restaurant-action--favorite {
+  background: #f4c95d;
+  color: #1f3631;
+}
+
+.restaurant-action--favorite:hover,
+.restaurant-action--favorite:focus-visible,
+.restaurant-action--favorite.is-active {
+  background: #f2b237;
+  color: #1f3631;
+  transform: none;
+}
+
 .restaurant-action--danger {
   background: #7a2e26;
 }


### PR DESCRIPTION
## Summary
- add a Favorites tab to the restaurants panel alongside Feed and Saved views
- allow users to mark restaurants as favorites with persistent storage and synchronized map updates
- surface the new favorites view in unit tests and styling, including updated tab labels

## Testing
- npm test
- npx vitest run tests/restaurants.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e58e846fc48327aae64d903e95e5f3