### PR TITLE
Handle Eventbrite fallback when remote API base fails

### DIFF
--- a/js/shows.js
+++ b/js/shows.js
@@ -1490,10 +1490,11 @@ export async function initShowsPanel() {
         if (requiresManualToken) {
           params.set('token', manualApiToken);
         }
-        const { endpoint: eventbriteEndpoint, isRemote } = resolveEventbriteEndpoint(apiBase);
-        const fallbackEndpoint = !isRemote && eventbriteEndpoint !== DEFAULT_EVENTBRITE_ENDPOINT
-          ? DEFAULT_EVENTBRITE_ENDPOINT
-          : null;
+        const { endpoint: eventbriteEndpoint } = resolveEventbriteEndpoint(apiBase);
+        const fallbackEndpoint =
+          eventbriteEndpoint !== DEFAULT_EVENTBRITE_ENDPOINT
+            ? DEFAULT_EVENTBRITE_ENDPOINT
+            : null;
 
         const primaryUrl = appendQuery(eventbriteEndpoint, params);
         const fallbackUrl = fallbackEndpoint ? appendQuery(fallbackEndpoint, params) : null;


### PR DESCRIPTION
## Summary
- ensure the Eventbrite client falls back to the deployed proxy even when a custom remote API_BASE_URL returns HTML or 404s
- refactor the shows panel tests to share a setup helper and cover the remote fallback scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e590f8ca2883279c454a97efffbc55