### PR TITLE
Hardcode Eventbrite token

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -34,7 +34,7 @@ const EVENTBRITE_API_TOKEN =
   process.env.EVENTBRITE_API_TOKEN ||
   process.env.EVENTBRITE_OAUTH_TOKEN ||
   process.env.EVENTBRITE_TOKEN ||
-  '';
+  '2YR3RA4K6VCZVEUZMBG4';
 const HAS_EVENTBRITE_TOKEN = Boolean(EVENTBRITE_API_TOKEN);
 const YELP_BASE_URL = 'https://api.yelp.com/v3/businesses/search';
 const YELP_CACHE_COLLECTION = 'yelpCache';

--- a/functions/index.js
+++ b/functions/index.js
@@ -164,7 +164,7 @@ function getEventbriteDefaultToken() {
   if (fromConfig && typeof fromConfig === 'object') {
     return fromConfig.token || fromConfig.key || fromConfig.oauth_token || null;
   }
-  return null;
+  return '2YR3RA4K6VCZVEUZMBG4';
 }
 
 function normalizeCoordinateFixed(value, digits = 3) {


### PR DESCRIPTION
## Summary
- default the backend Eventbrite proxy to the provided token so the service always advertises credentials
- mirror the hardcoded Eventbrite token in the Firebase Functions proxy helper

## Testing
- npm test -- eventbriteTokenDetection.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e592a2af3c8327b5d4db92d5548840