### PR TITLE
Prevent restaurants from appearing in multiple lists

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -903,7 +903,13 @@ function renderSavedSection() {
     setSavedRestaurants(filtered);
     list = savedRestaurants;
   }
-  renderRestaurantsList(container, list, 'No saved restaurants yet.');
+  const favoriteIds = new Set(
+    favoriteRestaurants
+      .map(item => normalizeId(item.id))
+      .filter(id => typeof id === 'string' && id)
+  );
+  const visibleSaved = list.filter(rest => !favoriteIds.has(normalizeId(rest.id)));
+  renderRestaurantsList(container, visibleSaved, 'No saved restaurants yet.');
 }
 
 function renderFavoritesSection() {

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -396,9 +396,9 @@ describe('initRestaurantsPanel', () => {
     expect(favoritesContainer?.textContent).toContain('Top Rated');
 
     const savedContainer = document.getElementById('restaurantsSaved');
-    expect(savedContainer?.textContent).toContain('Top Rated');
+    expect(savedContainer?.textContent).toContain('No saved restaurants yet.');
 
-    const savedToggle = savedContainer?.querySelector('.restaurant-action--secondary');
+    const savedToggle = favoritesContainer?.querySelector('.restaurant-action--secondary');
     expect(savedToggle?.textContent).toBe('Saved');
     savedToggle?.click();
 


### PR DESCRIPTION
## Summary
- hide favorited restaurants from the saved/"To Visit" list so each restaurant only shows in a single tab
- adjust the restaurants panel tests to cover the updated behavior when favoriting and unsaving

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5929953188327b321af85c2b557c8