### PR TITLE
Highlight restaurants on map when selecting cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -2786,6 +2786,17 @@ h2 {
   background: #f6faf7;
 }
 
+.leaflet-marker-icon {
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.leaflet-marker-icon.is-active {
+  filter: drop-shadow(0 0 10px rgba(37, 99, 235, 0.65));
+  transform: scale(1.08);
+  transform-origin: center bottom;
+  z-index: 1000 !important;
+}
+
 .restaurants-map--empty::after {
   content: 'Map updates once results are available';
   position: absolute;
@@ -2838,6 +2849,11 @@ h2 {
 .restaurant-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 18px 42px rgba(25, 55, 45, 0.18);
+}
+
+.restaurant-card.is-active {
+  border-color: rgba(37, 99, 235, 0.3);
+  box-shadow: 0 20px 50px rgba(37, 99, 235, 0.22);
 }
 
 .restaurant-card__header {


### PR DESCRIPTION
## Summary
- track restaurant cards and Leaflet markers so clicking a card opens the corresponding marker
- persist the active selection across list re-renders and marker refreshes
- add visual styles to emphasize the active restaurant card and map marker

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5935877288327a4807b09f06d1378