### PR TITLE
Add loading animation to movie feed status

### DIFF
--- a/style.css
+++ b/style.css
@@ -2676,6 +2676,62 @@ h2 {
   border: 1px solid transparent;
 }
 
+.movie-status--loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.5rem;
+}
+
+.movie-status__loader {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.movie-status__dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.6;
+  animation: movie-status-bounce 1s infinite ease-in-out;
+}
+
+.movie-status__dot:nth-of-type(2) {
+  animation-delay: 0.15s;
+}
+
+.movie-status__dot:nth-of-type(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes movie-status-bounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.6);
+    opacity: 0.3;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.movie-status__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .movie-status--info {
   border-color: #38bdf8;
 }


### PR DESCRIPTION
## Summary
- replace the movie feed status text with a reusable loading spinner while movie requests are in flight and log those messages to the console for visibility
- update feed refresh flows to enable the spinner during all movie-fetching states so the UI shows the animation instead of copy
- add styles for the animated status indicator, including accessible hidden text for screen readers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a78a7848832799961911a11e4a05