### PR TITLE
Relax restaurant review threshold fallback

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -944,7 +944,8 @@ function updateNearbyRestaurants() {
   const list = Array.isArray(rawNearbyRestaurants) ? rawNearbyRestaurants : [];
   const normalized = list.map(normalizeRestaurant).filter(Boolean);
   const filtered = normalized.filter(rest => getReviewCountValue(rest) >= 5);
-  nearbyRestaurants = sortByDistance(filtered);
+  const prioritized = filtered.length ? filtered : normalized;
+  nearbyRestaurants = sortByDistance(prioritized);
 }
 
 function renderRestaurantsList(container, items, emptyMessage) {


### PR DESCRIPTION
## Summary
- fall back to displaying all nearby restaurants when none meet the 5-review threshold so the list no longer renders empty

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a898dd2c8327bbade118d847da64