### PR TITLE
Prompt for rating when marking titles as watched

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -1216,6 +1216,7 @@ async function setStatus(movie, status, options = {}) {
   const next = { ...currentPrefs };
   const snapshot = summarizeMovie(movie);
   const entry = next[id] ? { ...next[id] } : {};
+  const skipRatingPrompt = Boolean(options.skipRatingPrompt);
   entry.status = status;
   entry.updatedAt = Date.now();
   if (status === 'interested') {
@@ -1234,9 +1235,41 @@ async function setStatus(movie, status, options = {}) {
   await savePreferences(next);
   pruneSuppressedMovies();
   refreshUI();
+  if (status === 'watched' && !skipRatingPrompt) {
+    await promptForUserRating(movie);
+  }
   if (!getFeedMovies(currentMovies).length) {
     requestAdditionalMovies();
   }
+}
+
+async function promptForUserRating(movie) {
+  if (!movie || movie.id == null) return;
+  const hasWindow = typeof window !== 'undefined' && window;
+  const promptFn = hasWindow && typeof window.prompt === 'function' ? window.prompt : null;
+  if (!promptFn) return;
+
+  const title = (movie.title || movie.name || '').trim() || 'this title';
+  const message = `Rate "${title}" on a scale of 0-10 (leave blank to skip).`;
+
+  let response;
+  try {
+    response = promptFn(message, '');
+  } catch (err) {
+    console.warn('Failed to prompt for movie rating', movie.id, err);
+    return;
+  }
+
+  if (response == null) return;
+  if (typeof response !== 'string') return;
+
+  const trimmed = response.trim();
+  if (!trimmed) return;
+
+  const value = Number.parseFloat(trimmed);
+  if (Number.isNaN(value)) return;
+
+  await setUserRating(movie.id, value);
 }
 
 async function setUserRating(movieId, rating) {

--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -934,6 +934,61 @@ describe('initMoviesPanel', () => {
     expect(document.querySelector('#movieList').textContent).toContain('Classic Film');
   });
 
+  it('prompts for a rating when marking a movie as watched', async () => {
+    const dom = buildDom();
+    attachWindow(dom);
+    window.tmdbApiKey = 'TEST_KEY';
+
+    const promptSpy = vi.fn(() => '8.5');
+    window.prompt = promptSpy;
+
+    const page = {
+      results: [
+        {
+          id: 12,
+          title: 'Prompt Test',
+          release_date: '2020-05-05',
+          vote_average: 7.8,
+          vote_count: 345,
+          overview: 'A movie to test prompts.',
+          genre_ids: [35]
+        }
+      ]
+    };
+    const empty = { results: [] };
+    const credits = {
+      cast: [{ name: 'Comedic Star' }],
+      crew: [{ job: 'Director', name: 'Funny Director' }]
+    };
+    const genres = { genres: [{ id: 35, name: 'Comedy' }] };
+
+    configureFetchResponses([
+      { results: [] },
+      page,
+      empty,
+      credits,
+      genres
+    ]);
+
+    await initMoviesPanel();
+
+    const watchedBtn = Array.from(document.querySelectorAll('#movieList li button')).find(
+      b => b.textContent === 'Watched Already'
+    );
+    watchedBtn?.click();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(promptSpy).toHaveBeenCalledTimes(1);
+    const promptMessage = promptSpy.mock.calls[0][0] || '';
+    expect(promptMessage).toContain('Rate "Prompt Test"');
+
+    const personalRatingInput = document.querySelector(
+      '#watchedMoviesList .movie-personal-rating input'
+    );
+    expect(personalRatingInput?.value).toBe('8.5');
+  });
+
   it('sorts watched movies by rating when selected', async () => {
     const dom = buildDom();
     attachWindow(dom);


### PR DESCRIPTION
## Summary
- prompt the user for a personal rating when marking movies or shows as watched
- guard against missing prompt support and save the entered score as the user rating
- add a regression test to verify that the watched flow captures the prompted rating

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a9795d5c832782a1a566232f1777