### PR TITLE
Replace movie genre dropdown with toggle chips

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,11 +106,9 @@
                   placeholder="e.g. 2024"
                 />
               </div>
-              <div class="movie-filter-field">
-                <label for="movieFilterGenre">Genre</label>
-                <select id="movieFilterGenre" name="movieFilterGenre">
-                  <option value="">All Genres</option>
-                </select>
+              <div class="movie-filter-field movie-filter-genre">
+                <span class="movie-filter-label">Genre</span>
+                <div id="movieFilterGenre" class="genre-filter"></div>
               </div>
             </div>
             <div id="movieStatus" class="movie-status" aria-live="polite"></div>

--- a/js/movies.js
+++ b/js/movies.js
@@ -338,6 +338,52 @@ function hasActiveFeedFilters() {
   return Object.values(feedFilterState).some(value => String(value ?? '').trim() !== '');
 }
 
+function updateFeedGenreUI() {
+  const container = domRefs.feedGenre;
+  if (!container) return;
+
+  const currentValue = feedFilterState.genreId ?? '';
+  const buttons = container.querySelectorAll('.genre-filter-btn');
+  buttons.forEach(btn => {
+    const value = btn.dataset.genre ?? '';
+    const isActive = value === currentValue;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+
+  const activeValueEl = container.querySelector('.genre-filter-active-value');
+  if (!activeValueEl) return;
+
+  activeValueEl.innerHTML = '';
+
+  if (currentValue && genreMap && Object.prototype.hasOwnProperty.call(genreMap, currentValue)) {
+    const chip = document.createElement('span');
+    chip.className = 'genre-filter-chip';
+
+    const text = document.createElement('span');
+    text.className = 'genre-filter-chip-text';
+    text.textContent = genreMap[currentValue] || 'Selected';
+    chip.appendChild(text);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'genre-filter-chip-remove';
+    removeBtn.setAttribute('aria-label', 'Clear genre filter');
+    removeBtn.textContent = '×';
+    removeBtn.addEventListener('click', () => {
+      setFeedFilter('genreId', '', { sanitize: true, persist: true });
+    });
+    chip.appendChild(removeBtn);
+
+    activeValueEl.appendChild(chip);
+  } else {
+    const span = document.createElement('span');
+    span.className = 'genre-filter-active-empty';
+    span.textContent = 'All genres';
+    activeValueEl.appendChild(span);
+  }
+}
+
 function updateFeedFilterInputsFromState() {
   if (domRefs.feedMinRating) {
     domRefs.feedMinRating.value = feedFilterState.minRating ?? '';
@@ -351,9 +397,7 @@ function updateFeedFilterInputsFromState() {
   if (domRefs.feedEndYear) {
     domRefs.feedEndYear.value = feedFilterState.endYear ?? '';
   }
-  if (domRefs.feedGenre) {
-    domRefs.feedGenre.value = feedFilterState.genreId ?? '';
-  }
+  updateFeedGenreUI();
 }
 
 function setFeedFilter(name, rawValue, { sanitize = false, persist = true } = {}) {
@@ -383,8 +427,8 @@ function setFeedFilter(name, rawValue, { sanitize = false, persist = true } = {}
 }
 
 function populateFeedGenreOptions() {
-  const select = domRefs.feedGenre;
-  if (!select) return;
+  const container = domRefs.feedGenre;
+  if (!container) return;
 
   const entries = Object.entries(genreMap || {}).sort((a, b) => {
     const nameA = String(a[1] ?? '');
@@ -393,35 +437,54 @@ function populateFeedGenreOptions() {
   });
 
   const currentValue = feedFilterState.genreId ?? '';
-  const fragment = document.createDocumentFragment();
-  const defaultOption = document.createElement('option');
-  defaultOption.value = '';
-  defaultOption.textContent = 'All Genres';
-  fragment.appendChild(defaultOption);
+  const availableIds = new Set(entries.map(([id]) => String(id)));
+  const needsReset = currentValue && !availableIds.has(currentValue);
 
-  let hasMatch = currentValue === '';
+  container.innerHTML = '';
+
+  const buttonsWrap = document.createElement('div');
+  buttonsWrap.className = 'genre-filter-buttons';
+  buttonsWrap.setAttribute('role', 'group');
+  buttonsWrap.setAttribute('aria-label', 'Filter movies by genre');
+
+  const createButton = (value, label) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'genre-filter-btn';
+    btn.dataset.genre = value;
+    btn.textContent = label;
+    btn.addEventListener('click', handleFeedGenreButtonClick);
+    buttonsWrap.appendChild(btn);
+  };
+
+  createButton('', 'All Genres');
   entries.forEach(([id, name]) => {
-    const option = document.createElement('option');
-    option.value = String(id);
-    option.textContent = String(name || 'Unknown');
-    if (!hasMatch && String(id) === currentValue) {
-      hasMatch = true;
-    }
-    fragment.appendChild(option);
+    createButton(String(id), String(name || 'Unknown'));
   });
 
-  select.innerHTML = '';
-  select.appendChild(fragment);
+  container.appendChild(buttonsWrap);
 
-  if (!hasMatch && currentValue) {
+  const activeWrap = document.createElement('div');
+  activeWrap.className = 'genre-filter-active';
+
+  const label = document.createElement('span');
+  label.className = 'genre-filter-active-label';
+  label.textContent = 'Active filter:';
+  activeWrap.appendChild(label);
+
+  const valueEl = document.createElement('div');
+  valueEl.className = 'genre-filter-active-value';
+  activeWrap.appendChild(valueEl);
+
+  container.appendChild(activeWrap);
+
+  if (needsReset) {
     feedFilterState = { ...feedFilterState, genreId: '' };
     saveFeedFilters(feedFilterState);
-    select.value = '';
     renderFeed();
-    return;
   }
 
-  select.value = currentValue;
+  updateFeedGenreUI();
 }
 
 function attachFeedFilterInput(element, name) {
@@ -461,6 +524,20 @@ function attachFeedFilterSelect(element, name) {
 
   element._feedFilterSelectHandler = handler;
   element.addEventListener('change', handler);
+}
+
+function handleFeedGenreButtonClick(event) {
+  event.preventDefault();
+  const button = event.currentTarget;
+  if (!button) return;
+
+  const value = button.dataset.genre ?? '';
+  const currentValue = feedFilterState.genreId ?? '';
+  const nextValue = currentValue === value ? '' : value;
+
+  if (nextValue === currentValue) return;
+
+  setFeedFilter('genreId', nextValue, { sanitize: true, persist: true });
 }
 
 async function loadPreferences() {
@@ -2637,7 +2714,6 @@ export async function initMoviesPanel() {
   attachFeedFilterInput(domRefs.feedMinVotes, 'minVotes');
   attachFeedFilterInput(domRefs.feedStartYear, 'startYear');
   attachFeedFilterInput(domRefs.feedEndYear, 'endYear');
-  attachFeedFilterSelect(domRefs.feedGenre, 'genreId');
 
   const storedKey =
     (typeof window !== 'undefined' && window.tmdbApiKey) ||

--- a/style.css
+++ b/style.css
@@ -2445,6 +2445,17 @@ h2 {
   outline-offset: 2px;
 }
 
+.genre-filter-active-value {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.genre-filter-active-empty {
+  font-size: 0.85rem;
+  color: #555;
+}
+
 .movie-tab,
 .shows-tab {
   flex: 1 1 0;
@@ -2649,7 +2660,8 @@ h2 {
   gap: 0.25rem;
 }
 
-.movie-filter-field label {
+.movie-filter-field label,
+.movie-filter-label {
   font-size: 0.85rem;
   font-weight: 600;
 }
@@ -2664,6 +2676,22 @@ h2 {
 
 .movie-filter-field input {
   min-width: 6.5rem;
+}
+
+.movie-filter-field.movie-filter-genre {
+  flex: 1 1 100%;
+}
+
+.movie-filter-field.movie-filter-genre .genre-filter {
+  margin-bottom: 0;
+}
+
+.movie-filter-field.movie-filter-genre .genre-filter-buttons {
+  gap: 8px;
+}
+
+.movie-filter-field.movie-filter-genre .genre-filter-btn {
+  padding: 4px 10px;
 }
 
 .movie-status {

--- a/tests/movies.test.js
+++ b/tests/movies.test.js
@@ -31,7 +31,7 @@ function buildDom() {
         <input id="movieFilterMinVotes" type="number" />
         <input id="movieFilterStartYear" type="number" />
         <input id="movieFilterEndYear" type="number" />
-        <select id="movieFilterGenre"></select>
+        <div id="movieFilterGenre" class="genre-filter"></div>
       </div>
       <div id="movieStatus" class="movie-status"></div>
       <div id="movieList"></div>


### PR DESCRIPTION
## Summary
- replace the movie stream genre select with an inline tag toggle container
- render genre filter buttons and active chip state in the movie feed script and add supporting styles
- update the unit test DOM fixture to use the new genre filter container

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b55326d483278b49212035ef9d57