### PR TITLE
Allow saving TV preferences in Firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -73,6 +73,11 @@ service cloud.firestore {
       allow read, write: if true;
     }
 
+    // 10) TV show preferences stored at /tvPreferences/{uid}
+    match /tvPreferences/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // Everything else locked down
     match /{document=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Summary
- allow authenticated users to read and write their TV preference documents by updating Firestore security rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e5bb6431f8832796ce023f9ff2d4b7