### PR TITLE
Enforce minimum review count for restaurant listings

### DIFF
--- a/js/restaurants.js
+++ b/js/restaurants.js
@@ -949,7 +949,7 @@ function getReviewCountValue(rest) {
 }
 
 function hasReviews(rest) {
-  return getReviewCountValue(rest) > 0;
+  return getReviewCountValue(rest) >= 5;
 }
 
 function filterReviewableRestaurants(items = []) {

--- a/tests/restaurants.test.js
+++ b/tests/restaurants.test.js
@@ -404,7 +404,7 @@ describe('initRestaurantsPanel', () => {
     expect(nearbyContainer?.textContent).toContain('Top Rated');
   });
 
-  it('surfaces fallback restaurants after hiding higher-review picks', async () => {
+  it('does not surface restaurants with fewer than five reviews when higher-review picks are hidden', async () => {
     const dom = setupDom();
     global.window = dom.window;
     global.document = dom.window.document;
@@ -448,16 +448,16 @@ describe('initRestaurantsPanel', () => {
       card?.querySelector('.restaurant-action--danger')?.click();
     };
 
+    const nearbyContainer = document.getElementById('restaurantsNearby');
+    const initialHeadings = Array.from(
+      nearbyContainer.querySelectorAll('h3')
+    ).map(element => element.textContent);
+    expect(initialHeadings).toEqual(['Critics Choice', 'Popular Spot']);
+
     hideByName('Critics Choice');
     hideByName('Popular Spot');
 
-    const nearbyContainer = document.getElementById('restaurantsNearby');
-    const headings = Array.from(
-      nearbyContainer.querySelectorAll('h3')
-    ).map(element => element.textContent);
-
-    expect(headings).toEqual(['Neighborhood Diner', 'Late Night Bites']);
-    expect(nearbyContainer.textContent).not.toContain('No restaurants found.');
+    expect(nearbyContainer.textContent).toContain('No restaurants found.');
   });
 
   it('allows favoriting restaurants and keeps favorites in sync with saved list', async () => {


### PR DESCRIPTION
## Summary
- require restaurant entries to have at least five reviews before they are eligible for display
- update the restaurant panel test to confirm that low-review options do not surface after hiding higher-review picks

## Testing
- npm test -- restaurants.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5bcfce83883278182b766f87ef561