### PR TITLE
Switch TV genre filter to tag toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,11 +199,9 @@
                   placeholder="e.g. 2024"
                 />
               </div>
-              <div class="movie-filter-field">
-                <label for="tvFilterGenre">Genre</label>
-                <select id="tvFilterGenre" name="tvFilterGenre">
-                  <option value="">All Genres</option>
-                </select>
+              <div class="movie-filter-field movie-filter-genre">
+                <span class="movie-filter-label">Genre</span>
+                <div id="tvFilterGenre" class="genre-filter"></div>
               </div>
             </div>
             <div id="tvStatus" class="movie-status" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- replace the TV stream genre dropdown with the shared tag-style genre filter markup
- render and manage the TV genre filter using toggle buttons and chips to match the movie experience

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e5bd252ca48327a11cbb9786df3d08