### PR TITLE
Add dancing progress animation for TV feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
                 </select>
               </div>
             </div>
-            <div id="tvStatus" class="movie-status" aria-live="polite"></div>
+            <div id="tvStatus" class="movie-status tv-status" aria-live="polite"></div>
             <div id="tvList" class="decision-container"></div>
           </div>
           <div id="savedTvSection" style="display:none;">

--- a/js/tv.js
+++ b/js/tv.js
@@ -92,6 +92,15 @@ const STATUS_TONE_CLASSES = Object.freeze({
   error: 'movie-status--error'
 });
 
+function escapeForAttribute(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 let loadAttemptCounter = 0;
 
 function formatTimestamp(value) {
@@ -119,15 +128,71 @@ function summarizeError(err) {
   return 'Unknown error';
 }
 
-function updateFeedStatus(message, { tone = 'info' } = {}) {
+function updateFeedStatus(message, { tone = 'info', showSpinner = false } = {}) {
   const statusEl = domRefs.feedStatus;
   if (!statusEl) return;
-  statusEl.textContent = message;
+  const normalizedMessage = typeof message === 'string' ? message : String(message ?? '');
+  const isCooldownMessage = /before requesting more tv shows/i.test(normalizedMessage);
+
+  if (isCooldownMessage) {
+    const fallbackLabel = normalizedMessage.trim()
+      ? normalizedMessage.trim()
+      : 'Preparing more TV shows shortly';
+    const ariaLabel = escapeForAttribute(fallbackLabel);
+    statusEl.innerHTML = `
+      <div class="tv-status__party" role="status" aria-live="polite"${
+        ariaLabel ? ` aria-label="${ariaLabel}"` : ''
+      }>
+        <span class="movie-status__sr">${ariaLabel || 'Preparing more TV shows shortly'}</span>
+        <div class="tv-status__stage">
+          <span class="tv-status__dancer tv-status__dancer--left"></span>
+          <span class="tv-status__dancer tv-status__dancer--center"></span>
+          <span class="tv-status__dancer tv-status__dancer--right"></span>
+        </div>
+        <div class="tv-status__lights">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </div>
+    `;
+    statusEl.setAttribute('aria-busy', 'true');
+    if (normalizedMessage.trim()) {
+      console.info(normalizedMessage);
+    }
+  } else if (showSpinner) {
+    const ariaLabel = normalizedMessage.trim() ? escapeForAttribute(normalizedMessage) : '';
+    statusEl.innerHTML = `
+      <div class="tv-status__party" role="status" aria-live="polite"${
+        ariaLabel ? ` aria-label="${ariaLabel}"` : ''
+      }>
+        <span class="movie-status__sr">${ariaLabel}</span>
+        <div class="tv-status__stage">
+          <span class="tv-status__dancer tv-status__dancer--left"></span>
+          <span class="tv-status__dancer tv-status__dancer--center"></span>
+          <span class="tv-status__dancer tv-status__dancer--right"></span>
+        </div>
+        <div class="tv-status__lights">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </div>
+    `;
+    statusEl.setAttribute('aria-busy', 'true');
+    if (normalizedMessage.trim()) {
+      console.info(normalizedMessage);
+    }
+  } else {
+    statusEl.textContent = normalizedMessage;
+    statusEl.removeAttribute('aria-busy');
+  }
   Object.values(STATUS_TONE_CLASSES).forEach(cls => {
     statusEl.classList.remove(cls);
   });
   const toneClass = STATUS_TONE_CLASSES[tone] || STATUS_TONE_CLASSES.info;
   statusEl.classList.add(toneClass);
+  statusEl.classList.toggle('movie-status--loading', Boolean(showSpinner || isCooldownMessage));
 }
 
 function clampUserRating(value) {
@@ -1344,7 +1409,10 @@ async function requestAdditionalMovies() {
   if (refillInProgress) {
     const started = formatTimestamp(lastRefillAttempt);
     const label = started ? ` (started at ${started})` : '';
-    updateFeedStatus(`Movie request already in progress${label}.`, { tone: 'info' });
+    updateFeedStatus(`TV show request already in progress${label}.`, {
+      tone: 'info',
+      showSpinner: true
+    });
     return;
   }
   if (now - lastRefillAttempt < REFILL_COOLDOWN_MS) {
@@ -1383,7 +1451,7 @@ function renderFeed() {
   if (!currentMovies.length) {
     if (refillInProgress) {
       listEl.innerHTML = '<em>Loading more TV shows...</em>';
-      updateFeedStatus('Waiting for TV shows from TMDB...', { tone: 'info' });
+      updateFeedStatus('Waiting for TV shows from TMDB...', { tone: 'info', showSpinner: true });
       return;
     }
     if (feedExhausted) {
@@ -1399,7 +1467,10 @@ function renderFeed() {
       return;
     }
     listEl.innerHTML = '<em>Loading more TV shows...</em>';
-    updateFeedStatus('Requesting the first batch of TV shows...', { tone: 'info' });
+    updateFeedStatus('Requesting the first batch of TV shows...', {
+      tone: 'info',
+      showSpinner: true
+    });
     requestAdditionalMovies();
     return;
   }
@@ -1410,14 +1481,15 @@ function renderFeed() {
     if (refillInProgress) {
       listEl.innerHTML = '<em>Loading more TV shows...</em>';
       updateFeedStatus('All current results are hidden; waiting for new TV shows...', {
-        tone: 'info'
+        tone: 'info',
+        showSpinner: true
       });
       return;
     }
     listEl.innerHTML = '<em>Loading more TV shows...</em>';
     updateFeedStatus(
       'All fetched TV shows are hidden by saved statuses. Looking for fresh titles...',
-      { tone: 'warning' }
+      { tone: 'warning', showSpinner: true }
     );
     requestAdditionalMovies();
     return;
@@ -1429,7 +1501,8 @@ function renderFeed() {
     if (refillInProgress) {
       listEl.innerHTML = '<em>Loading more TV shows...</em>';
       updateFeedStatus('Filters removed the current batch; waiting for more TV shows...', {
-        tone: 'info'
+        tone: 'info',
+        showSpinner: true
       });
       return;
     }
@@ -1449,9 +1522,9 @@ function renderFeed() {
     const hiddenByFilters = availableMovies.length;
     updateFeedStatus(
       hiddenByFilters
-        ? `Filters are hiding ${hiddenByFilters} movie${hiddenByFilters === 1 ? '' : 's'}; requesting more options...`
+        ? `Filters are hiding ${hiddenByFilters} show${hiddenByFilters === 1 ? '' : 's'}; requesting more options...`
         : 'Filters removed the current batch; requesting more TV shows...',
-      { tone: 'warning' }
+      { tone: 'warning', showSpinner: true }
     );
     requestAdditionalMovies();
     return;
@@ -1517,7 +1590,7 @@ function renderFeed() {
   listEl.innerHTML = '';
   listEl.appendChild(ul);
   updateFeedStatus(
-    `Showing ${filteredMovies.length} movie${filteredMovies.length === 1 ? '' : 's'} (updated ${formatTimestamp(
+    `Showing ${filteredMovies.length} show${filteredMovies.length === 1 ? '' : 's'} (updated ${formatTimestamp(
       Date.now()
     )}).`,
     { tone: 'success' }
@@ -2408,7 +2481,7 @@ async function loadMovies({ attemptStart } = {}) {
     `Loading TV shows (attempt ${attemptNumber})${
       startedLabel ? ` started at ${startedLabel}` : ''
     }. ${attemptIntro}${fallbackNote}`,
-    { tone: 'info' }
+    { tone: 'info', showSpinner: true }
   );
 
   listEl.innerHTML = '<em>Loading...</em>';

--- a/style.css
+++ b/style.css
@@ -2920,6 +2920,169 @@ h2 {
   }
 }
 
+.tv-status__party {
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
+}
+
+.tv-status__stage {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.55rem;
+  padding: 0.55rem 0.75rem 0.9rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.45), rgba(236, 72, 153, 0.4));
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12), 0 8px 18px rgba(15, 23, 42, 0.15);
+  overflow: visible;
+  min-width: 7rem;
+}
+
+.tv-status__stage::before {
+  content: '';
+  position: absolute;
+  left: -10%;
+  right: -10%;
+  bottom: -0.35rem;
+  height: 1.05rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.05), rgba(15, 23, 42, 0.25));
+  border-radius: 50%;
+  filter: blur(2px);
+}
+
+.tv-status__dancer {
+  position: relative;
+  width: 0.75rem;
+  height: 1.55rem;
+  border-radius: 0.4rem;
+  background: linear-gradient(180deg, rgba(248, 113, 113, 0.95), rgba(251, 191, 36, 0.9));
+  transform-origin: bottom center;
+  animation: tv-status-dancer-left 1.2s ease-in-out infinite;
+}
+
+.tv-status__dancer::before {
+  content: '';
+  position: absolute;
+  top: -0.45rem;
+  left: 50%;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #f8fafc;
+  transform: translateX(-50%);
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.12);
+}
+
+.tv-status__dancer::after {
+  content: '';
+  position: absolute;
+  top: 0.35rem;
+  left: 50%;
+  width: 0.85rem;
+  height: 0.22rem;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.6);
+  transform: translateX(-50%);
+  animation: tv-status-dancer-hands 1s ease-in-out infinite;
+}
+
+.tv-status__dancer--center {
+  height: 1.8rem;
+  background: linear-gradient(180deg, rgba(129, 140, 248, 0.95), rgba(59, 130, 246, 0.85));
+  animation: tv-status-dancer-center 1.3s ease-in-out infinite;
+}
+
+.tv-status__dancer--center::after {
+  animation-duration: 1.2s;
+}
+
+.tv-status__dancer--right {
+  background: linear-gradient(180deg, rgba(249, 115, 22, 0.95), rgba(236, 72, 153, 0.88));
+  animation: tv-status-dancer-right 1.25s ease-in-out infinite;
+  animation-delay: 0.1s;
+}
+
+.tv-status__lights {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.tv-status__lights span {
+  width: 0.45rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(129, 140, 248, 0.85), rgba(129, 140, 248, 0));
+  transform-origin: top center;
+  animation: tv-status-light-beam 1.4s ease-in-out infinite;
+  opacity: 0.85;
+}
+
+.tv-status__lights span:nth-of-type(2) {
+  background: linear-gradient(180deg, rgba(236, 72, 153, 0.85), rgba(236, 72, 153, 0));
+  animation-delay: 0.15s;
+}
+
+.tv-status__lights span:nth-of-type(3) {
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.85), rgba(59, 130, 246, 0));
+  animation-delay: 0.3s;
+}
+
+@keyframes tv-status-dancer-left {
+  0%,
+  100% {
+    transform: rotate(-6deg) translateY(0);
+  }
+  50% {
+    transform: rotate(10deg) translateY(-0.4rem);
+  }
+}
+
+@keyframes tv-status-dancer-center {
+  0%,
+  100% {
+    transform: scale(1) translateY(0);
+  }
+  40% {
+    transform: scale(1.08) translateY(-0.5rem);
+  }
+  60% {
+    transform: scale(0.98) translateY(-0.25rem);
+  }
+}
+
+@keyframes tv-status-dancer-right {
+  0%,
+  100% {
+    transform: rotate(8deg) translateY(0);
+  }
+  50% {
+    transform: rotate(-12deg) translateY(-0.35rem);
+  }
+}
+
+@keyframes tv-status-dancer-hands {
+  0%,
+  100% {
+    transform: translateX(-50%) rotate(0deg);
+  }
+  50% {
+    transform: translateX(-50%) rotate(6deg);
+  }
+}
+
+@keyframes tv-status-light-beam {
+  0%,
+  100% {
+    transform: rotate(0deg) scaleY(0.85);
+    opacity: 0.7;
+  }
+  50% {
+    transform: rotate(6deg) scaleY(1.05);
+    opacity: 1;
+  }
+}
+
 .movie-status__sr {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary
- add a TV-specific loading state that renders a dancing status animation and exposes accessible labels
- trigger the animated loader during TV feed loading and cooldown flows while updating on-screen copy for shows
- style the new dancing stage, dancers, and lights for the TV status container

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5bd8e066c8327b66daca9dc35f37f