### PR TITLE
Split watched lists into rated/unrated columns

### DIFF
--- a/js/movies.js
+++ b/js/movies.js
@@ -2114,8 +2114,23 @@ function renderWatchedList() {
     return;
   }
 
-  const ul = document.createElement('ul');
+  const rated = [];
+  const unrated = [];
+
+  const hasUserRating = pref => {
+    if (pref.userRating == null || pref.userRating === '') return false;
+    return clampUserRating(Number(pref.userRating)) != null;
+  };
+
   sorted.forEach(pref => {
+    if (hasUserRating(pref)) {
+      rated.push(pref);
+    } else {
+      unrated.push(pref);
+    }
+  });
+
+  const createCard = pref => {
     const movie = pref.movie;
     const li = document.createElement('li');
     li.className = 'movie-card';
@@ -2169,11 +2184,40 @@ function renderWatchedList() {
     info.appendChild(controls);
 
     li.appendChild(info);
-    ul.appendChild(li);
-  });
+    return li;
+  };
+
+  const createColumn = (title, prefs, emptyMessage) => {
+    const column = document.createElement('section');
+    column.className = 'watched-column';
+
+    const heading = document.createElement('h4');
+    heading.textContent = title;
+    column.appendChild(heading);
+
+    if (!prefs.length) {
+      const empty = document.createElement('p');
+      empty.className = 'watched-empty';
+      empty.innerHTML = `<em>${emptyMessage}</em>`;
+      column.appendChild(empty);
+      return column;
+    }
+
+    const columnList = document.createElement('ul');
+    prefs.forEach(pref => {
+      columnList.appendChild(createCard(pref));
+    });
+    column.appendChild(columnList);
+    return column;
+  };
+
+  const container = document.createElement('div');
+  container.className = 'watched-columns';
+  container.appendChild(createColumn('Rated', rated, 'No rated movies yet.'));
+  container.appendChild(createColumn('Unrated', unrated, 'No unrated movies yet.'));
 
   listEl.innerHTML = '';
-  listEl.appendChild(ul);
+  listEl.appendChild(container);
 }
 
 function refreshUI() {

--- a/js/tv.js
+++ b/js/tv.js
@@ -2003,8 +2003,23 @@ function renderWatchedList() {
     return;
   }
 
-  const ul = document.createElement('ul');
+  const rated = [];
+  const unrated = [];
+
+  const hasUserRating = pref => {
+    if (pref.userRating == null || pref.userRating === '') return false;
+    return clampUserRating(Number(pref.userRating)) != null;
+  };
+
   sorted.forEach(pref => {
+    if (hasUserRating(pref)) {
+      rated.push(pref);
+    } else {
+      unrated.push(pref);
+    }
+  });
+
+  const createCard = pref => {
     const movie = pref.movie;
     const li = document.createElement('li');
     li.className = 'movie-card';
@@ -2062,11 +2077,40 @@ function renderWatchedList() {
     info.appendChild(controls);
 
     li.appendChild(info);
-    ul.appendChild(li);
-  });
+    return li;
+  };
+
+  const createColumn = (title, prefs, emptyMessage) => {
+    const column = document.createElement('section');
+    column.className = 'watched-column';
+
+    const heading = document.createElement('h4');
+    heading.textContent = title;
+    column.appendChild(heading);
+
+    if (!prefs.length) {
+      const empty = document.createElement('p');
+      empty.className = 'watched-empty';
+      empty.innerHTML = `<em>${emptyMessage}</em>`;
+      column.appendChild(empty);
+      return column;
+    }
+
+    const columnList = document.createElement('ul');
+    prefs.forEach(pref => {
+      columnList.appendChild(createCard(pref));
+    });
+    column.appendChild(columnList);
+    return column;
+  };
+
+  const container = document.createElement('div');
+  container.className = 'watched-columns';
+  container.appendChild(createColumn('Rated', rated, 'No rated shows yet.'));
+  container.appendChild(createColumn('Unrated', unrated, 'No unrated shows yet.'));
 
   listEl.innerHTML = '';
-  listEl.appendChild(ul);
+  listEl.appendChild(container);
 }
 
 function refreshUI() {

--- a/style.css
+++ b/style.css
@@ -2682,6 +2682,42 @@ h2 {
   background: #f9f9f9;
 }
 
+.watched-columns {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.watched-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.watched-column h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.watched-column ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.watched-column ul > .movie-card {
+  margin-bottom: 0;
+}
+
+.watched-empty {
+  margin: 0;
+  color: #555;
+}
+
 .movie-card img {
   width: 100px;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- split watched movie and TV entries into rated and unrated lists while preserving existing card rendering
- add layout styles so the new columns display side-by-side with spacing and empty states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5be8bf7f883279f4ed6a399fdc12c