### PR TITLE
Add Eventbrite API response debug view to Live Music panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,6 +249,10 @@
             </p>
           </div>
           <div id="eventbriteStatus" class="shows-status" role="status" aria-live="polite"></div>
+          <details id="eventbriteDebug" class="shows-debug" hidden>
+            <summary>Latest API response</summary>
+            <pre id="eventbriteDebugOutput" class="shows-debug__output" aria-live="polite"></pre>
+          </details>
           <div id="eventbriteList" class="decision-container"></div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -578,6 +578,62 @@ button:hover {
   width: 100%;
 }
 
+.shows-debug {
+  margin: 1rem 0;
+  border: 1px solid #d7e5dd;
+  border-radius: 8px;
+  background: #f6fbf8;
+  font-size: 0.85rem;
+  color: #34423a;
+  overflow: hidden;
+}
+
+.shows-debug[hidden] {
+  display: none;
+}
+
+.shows-debug summary {
+  cursor: pointer;
+  padding: 0.6rem 0.9rem;
+  font-weight: 600;
+  list-style: none;
+  outline: none;
+}
+
+.shows-debug summary::-webkit-details-marker {
+  display: none;
+}
+
+.shows-debug summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.5rem;
+  transition: transform 0.2s ease;
+}
+
+.shows-debug[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.shows-debug[data-state='error'] {
+  border-color: #f5b7b1;
+  background: #fff5f5;
+  color: #6d1f1f;
+}
+
+.shows-debug__output {
+  margin: 0;
+  padding: 0.75rem 0.9rem 1rem;
+  background: transparent;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow: auto;
+}
+
 .shows-discover-btn {
   display: inline-flex;
   align-items: center;

--- a/tests/showsEventbrite.test.js
+++ b/tests/showsEventbrite.test.js
@@ -43,6 +43,10 @@ describe('initShowsPanel (Eventbrite)', () => {
       <input id="eventbriteApiToken" />
       <button id="eventbriteDiscoverBtn">Discover</button>
       <div id="eventbriteStatus"></div>
+      <details id="eventbriteDebug" hidden>
+        <summary>Latest API response</summary>
+        <pre id="eventbriteDebugOutput"></pre>
+      </details>
       <div id="eventbriteList"></div>
     `, { url: 'http://localhost/' });
 
@@ -126,6 +130,12 @@ describe('initShowsPanel (Eventbrite)', () => {
 
     const status = document.getElementById('eventbriteStatus');
     expect(status.textContent).toContain('Found 1 upcoming event');
+
+    const debugContainer = document.getElementById('eventbriteDebug');
+    const debugOutput = document.getElementById('eventbriteDebugOutput');
+    expect(debugContainer.hidden).toBe(false);
+    expect(debugOutput.textContent).toContain('Request URL:');
+    expect(debugOutput.textContent).toContain('Live Show');
   });
 
   it('shows a helpful message when geolocation fails', async () => {
@@ -143,5 +153,6 @@ describe('initShowsPanel (Eventbrite)', () => {
 
     expect(fetch).not.toHaveBeenCalled();
     expect(document.getElementById('eventbriteStatus').textContent).toContain('Location access was denied');
+    expect(document.getElementById('eventbriteDebug').hidden).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add a collapsible debug panel to the Live Music tab to show the latest Eventbrite request and response details
- capture request metadata in the Live Music script so successful and failed searches expose the API payloads
- expand the Eventbrite unit tests to cover the debug output and keep it hidden when the search cannot start

## Testing
- npm test -- tests/showsEventbrite.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5c161dcac832788e60086dea11171