### PR TITLE
Fix duplicate feed genre handler declaration

### DIFF
--- a/js/tv.js
+++ b/js/tv.js
@@ -736,20 +736,6 @@ function attachFeedFilterSelect(element, name) {
   element.addEventListener('change', handler);
 }
 
-function handleFeedGenreButtonClick(event) {
-  event.preventDefault();
-  const button = event.currentTarget;
-  if (!button) return;
-
-  const value = button.dataset.genre ?? '';
-  const currentValue = feedFilterState.genreId ?? '';
-  const nextValue = currentValue === value ? '' : value;
-
-  if (nextValue === currentValue) return;
-
-  setFeedFilter('genreId', nextValue, { sanitize: true, persist: true });
-}
-
 function handleFeedExcludeGenreButtonClick(event) {
   event.preventDefault();
   const button = event.currentTarget;


### PR DESCRIPTION
## Summary
- remove the duplicate handleFeedGenreButtonClick definition in tv.js to avoid redeclaration errors in the browser

## Testing
- vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e5ca4051148327b3f1524884f0c444